### PR TITLE
fix(router): redirect authenticated users on root

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,7 +14,14 @@ function App() {
     return (
         <BrowserRouter>
             <Routes>
-                <Route path="/" element={<LandingPage />} />
+                <Route
+                    path="/"
+                    element={
+                        <PublicOnlyRoute>
+                            <LandingPage />
+                        </PublicOnlyRoute>
+                    }
+                />
                 <Route
                     path="/dashboard"
                     element={


### PR DESCRIPTION
## Fix/Feature: Redirect Authenticated Users on Root (Closes #17)

### Description
This PR resolves the suboptimal UX flow where users who are already logged in are served the static marketing landing page when navigating to the root URL (`/`). It wraps the root route in a `PublicOnlyRoute` guard, which automatically redirects signed-in users straight to the dashboard (`/dashboard`).

### Root Cause
In `src/App.tsx`, the root route (`path="/"`) was mapped directly to `<LandingPage />` without any authentication guards. Because it bypassed the route guards entirely, already-logged-in users had to manually navigate to `/dashboard` or `/chats`.

### Changes
- `src/App.tsx`: Wrapped the root `/` path in the `PublicOnlyRoute` guard. This checks for active, unexpired JWT tokens in local storage synchronously prior to mounting `LandingPage` and performs an instant history replacement to `/dashboard`.

### How to Verify
- [ ] `npm run dev` → navigate to `http://localhost:5173/` while unauthenticated to confirm the Landing Page still renders perfectly.
- [ ] Simulate or complete a user login (storing a valid `docchat_auth` token in local storage).
- [ ] Navigate to the root route `http://localhost:5173/` again and confirm it immediately redirects to `/dashboard` client-side without flashing the landing page first.
- [x] Verify that clicking the browser back button does not redirect you again (clean history replacement).

### Screenshots
Verified by client-side routing redirects.
