### PR TITLE
feat: add in-browser caching for mostly-static API data

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,4 +1,10 @@
-import { forceSignOut, getAccessToken } from "./auth";
+import { forceSignOut, getAccessToken, getAuthUser } from "./auth";
+import {
+    getFromCache,
+    setInCache,
+    removeFromCache,
+    removeMatchingFromCache,
+} from "./cache";
 
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || "http://localhost:3000/api/v1";
 
@@ -86,39 +92,101 @@ const apiRequest = async <T>(path: string, init?: RequestInit): Promise<T> => {
     return (payload.data ?? ({} as T)) as T;
 };
 
+const cacheKey = (path: string) => {
+    const userId = getAuthUser()?.id || "anon";
+    return `api:${userId}:${path}`;
+};
+
+async function withCache<T>(key: string, ttlMs: number, fetcher: () => Promise<T>): Promise<T> {
+    const cached = getFromCache<T>(key);
+    if (cached !== null) {
+        fetcher()
+            .then((value) => setInCache(key, value, ttlMs))
+            .catch(() => {});
+        return cached;
+    }
+    const value = await fetcher();
+    setInCache(key, value, ttlMs);
+    return value;
+}
+
+export const invalidateApiKeyCaches = () => {
+    const prefix = cacheKey("");
+    removeMatchingFromCache(`${prefix}/apikey/list`);
+    removeMatchingFromCache(`${prefix}/apikey/count`);
+};
+
+export const invalidateChatCaches = () => {
+    const prefix = cacheKey("");
+    removeMatchingFromCache(`${prefix}/chat/list`);
+    removeMatchingFromCache(`${prefix}/chat/recent`);
+};
+
+export const invalidateChatMessages = (chatId: string) => {
+    removeFromCache(cacheKey(`/message/all/${chatId}`));
+};
+
+export const invalidatePagesIndexed = (chatId: string) => {
+    removeFromCache(cacheKey(`/chat/pages-indexed/${chatId}`));
+};
+
+export const invalidateUserCache = () => {
+    const prefix = cacheKey("");
+    removeMatchingFromCache(prefix);
+};
+
 export const getUserProfile = () =>
-    apiRequest<{
-        id: string;
-        fullname?: string | null;
-        username?: string | null;
-        email?: string | null;
-    }>("/user/profile", { method: "GET" });
+    withCache(cacheKey("/user/profile"), 30 * 60 * 1000, () =>
+        apiRequest<{
+            id: string;
+            fullname?: string | null;
+            username?: string | null;
+            email?: string | null;
+        }>("/user/profile", { method: "GET" }),
+    );
 
 export const getApiKeys = () => apiRequest<{ apiKeys: ApiKeyItem[] }>("/apikey/list", { method: "GET" });
 
-export const createApiKey = (payload: { key: string; name: string; provider: Provider }) =>
-    apiRequest("/apikey/add", {
+export const createApiKey = async (payload: { key: string; name: string; provider: Provider }) => {
+    const result = await apiRequest("/apikey/add", {
         method: "POST",
         body: JSON.stringify(payload),
     });
+    invalidateApiKeyCaches();
+    return result;
+};
 
-export const deleteApiKey = (id: string) => apiRequest(`/apikey/${id}`, { method: "DELETE" });
+export const deleteApiKey = async (id: string) => {
+    const result = await apiRequest(`/apikey/${id}`, { method: "DELETE" });
+    invalidateApiKeyCaches();
+    return result;
+};
 
 export const getApiKeyCount = () => apiRequest<{ count: number }>("/apikey/count", { method: "GET" });
 
-export const getChats = () => apiRequest<ChatItem[]>("/chat/list", { method: "GET" });
+export const getChats = () =>
+    withCache(cacheKey("/chat/list"), 5 * 60 * 1000, () =>
+        apiRequest<ChatItem[]>("/chat/list", { method: "GET" }),
+    );
 
-export const createChat = (payload: {
+export const createChat = async (payload: {
     name?: string;
     docsUrl: string;
     isVectorLess?: boolean;
-}) =>
-    apiRequest<{ chatId?: string; id?: string }>("/chat/create", {
+}) => {
+    const result = await apiRequest<{ chatId?: string; id?: string }>("/chat/create", {
         method: "POST",
         body: JSON.stringify(payload),
     });
+    invalidateChatCaches();
+    return result;
+};
 
-export const deleteChat = (chatId: string) => apiRequest(`/chat/${chatId}`, { method: "DELETE" });
+export const deleteChat = async (chatId: string) => {
+    const result = await apiRequest(`/chat/${chatId}`, { method: "DELETE" });
+    invalidateChatCaches();
+    return result;
+};
 
 export const getChatStatus = (chatId: string) =>
     apiRequest<{ progress: { status: string; progress: number } }>(`/chat/status/${chatId}`, {
@@ -129,22 +197,30 @@ export const getChatDetails = (chatId: string) =>
     apiRequest<{ chat: ChatItem }>(`/chat/${chatId}`, { method: "GET" });
 
 export const getPagesIndexed = (chatId: string) =>
-    apiRequest<{
-        pagesIndexed: Array<{ pageUrl: string; title?: string | null }>;
-    }>(`/chat/pages-indexed/${chatId}`, { method: "GET" });
+    withCache(cacheKey(`/chat/pages-indexed/${chatId}`), 5 * 60 * 1000, () =>
+        apiRequest<{
+            pagesIndexed: Array<{ pageUrl: string; title?: string | null }>;
+        }>(`/chat/pages-indexed/${chatId}`, { method: "GET" }),
+    );
 
 export const getAvailableModels = () =>
-    apiRequest<{ models: string[] }>("/message/models", { method: "GET" });
+    withCache(cacheKey("/message/models"), 24 * 60 * 60 * 1000, () =>
+        apiRequest<{ models: string[] }>("/message/models", { method: "GET" }),
+    );
 
 export const getChatMessages = (chatId: string) =>
-    apiRequest<{ messages: ChatMessageItem[] }>(`/message/all/${chatId}`, {
-        method: "GET",
-    });
+    withCache(cacheKey(`/message/all/${chatId}`), 5 * 60 * 1000, () =>
+        apiRequest<{ messages: ChatMessageItem[] }>(`/message/all/${chatId}`, {
+            method: "GET",
+        }),
+    );
 
 export const getMessageSources = (messageId: string) =>
-    apiRequest<{ messageSources: ChatMessageSourceItem[] }>(`/message/sources/${messageId}`, {
-        method: "GET",
-    });
+    withCache(cacheKey(`/message/sources/${messageId}`), 5 * 60 * 1000, () =>
+        apiRequest<{ messageSources: ChatMessageSourceItem[] }>(`/message/sources/${messageId}`, {
+            method: "GET",
+        }),
+    );
 
 export const sendMessageStream = async (payload: {
     userPrompt: string;
@@ -192,6 +268,8 @@ export const sendMessageStream = async (payload: {
         text += tail;
         payload.onChunk?.(tail);
     }
+
+    invalidateChatMessages(payload.chatId);
     return text;
 };
 
@@ -224,32 +302,41 @@ export const exportChatMessages = async (chatId: string): Promise<void> => {
 };
 
 export const getLifetimeTokens = () =>
-    apiRequest<{
-        _sum: { inputTokens: number | null; outputTokens: number | null };
-    }>("/usage/lifetime-tokens", { method: "GET" });
+    withCache(cacheKey("/usage/lifetime-tokens"), 5 * 60 * 1000, () =>
+        apiRequest<{
+            _sum: { inputTokens: number | null; outputTokens: number | null };
+        }>("/usage/lifetime-tokens", { method: "GET" }),
+    );
 
 export const getTokensByGroup = (groupBy: "day" | "week" | "month" | "year") =>
-    apiRequest<
-        Record<
-            string,
-            {
-                period: string;
-                usageByModels: Array<{
-                    model: string;
-                    totalInput: number;
-                    totalOutput: number;
-                }>;
-            }
-        >
-    >(`/usage/tokens/${groupBy}`, { method: "GET" });
+    withCache(cacheKey(`/usage/tokens/${groupBy}`), 10 * 60 * 1000, () =>
+        apiRequest<
+            Record<
+                string,
+                {
+                    period: string;
+                    usageByModels: Array<{
+                        model: string;
+                        totalInput: number;
+                        totalOutput: number;
+                    }>;
+                }
+            >
+        >(`/usage/tokens/${groupBy}`, { method: "GET" }),
+    );
 
-export const getRecentChats = () => apiRequest<ChatItem[]>("/chat/recent", { method: "GET" });
+export const getRecentChats = () =>
+    withCache(cacheKey("/chat/recent"), 5 * 60 * 1000, () =>
+        apiRequest<ChatItem[]>("/chat/recent", { method: "GET" }),
+    );
 
 export const getTopChatsByUsage = () =>
-    apiRequest<
-        Array<{
-            chatId: string;
-            _sum: { inputTokens: number | null; outputTokens: number | null };
-            name?: string | null;
-        }>
-    >("/usage/top-chats", { method: "GET" });
+    withCache(cacheKey("/usage/top-chats"), 5 * 60 * 1000, () =>
+        apiRequest<
+            Array<{
+                chatId: string;
+                _sum: { inputTokens: number | null; outputTokens: number | null };
+                name?: string | null;
+            }>
+        >("/usage/top-chats", { method: "GET" }),
+    );

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,3 +1,5 @@
+import { clearCache } from "./cache";
+
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || "http://localhost:3000/api/v1";
 
 const AUTH_STORAGE_KEY = "docchat_auth";
@@ -88,6 +90,7 @@ export const clearAuthSession = () => {
 
 export const forceSignOut = (redirectTo = "/signin") => {
     clearAuthSession();
+    clearCache();
 
     if (window.location.pathname !== redirectTo) {
         window.location.replace(redirectTo);

--- a/src/lib/cache.ts
+++ b/src/lib/cache.ts
@@ -1,0 +1,50 @@
+const MAX_CACHE_SIZE = 200;
+
+interface CacheEntry<T> {
+    value: T;
+    expiresAt: number;
+}
+
+const store = new Map<string, CacheEntry<unknown>>();
+
+function sweepExpired(): void {
+    if (store.size < MAX_CACHE_SIZE) return;
+    const now = Date.now();
+    for (const [key, entry] of store) {
+        if (now > entry.expiresAt) {
+            store.delete(key);
+        }
+    }
+}
+
+export function getFromCache<T>(key: string): T | null {
+    const entry = store.get(key) as CacheEntry<T> | undefined;
+    if (!entry) return null;
+    if (Date.now() > entry.expiresAt) {
+        store.delete(key);
+        return null;
+    }
+    return entry.value;
+}
+
+export function setInCache<T>(key: string, value: T, ttlMs: number): void {
+    if (!Number.isFinite(ttlMs) || ttlMs <= 0) return;
+    sweepExpired();
+    store.set(key, { value, expiresAt: Date.now() + ttlMs });
+}
+
+export function clearCache(): void {
+    store.clear();
+}
+
+export function removeFromCache(key: string): void {
+    store.delete(key);
+}
+
+export function removeMatchingFromCache(substring: string): void {
+    for (const key of store.keys()) {
+        if (key.includes(substring)) {
+            store.delete(key);
+        }
+    }
+}

--- a/src/lib/cache.ts
+++ b/src/lib/cache.ts
@@ -1,4 +1,4 @@
-const MAX_CACHE_SIZE = 200;
+const SWEEP_INTERVAL_MS = 5 * 60 * 1000;
 
 interface CacheEntry<T> {
     value: T;
@@ -8,7 +8,6 @@ interface CacheEntry<T> {
 const store = new Map<string, CacheEntry<unknown>>();
 
 function sweepExpired(): void {
-    if (store.size < MAX_CACHE_SIZE) return;
     const now = Date.now();
     for (const [key, entry] of store) {
         if (now > entry.expiresAt) {
@@ -16,6 +15,22 @@ function sweepExpired(): void {
         }
     }
 }
+
+let sweepTimer: ReturnType<typeof setInterval> | null = null;
+
+function startSweepTimer(): void {
+    if (sweepTimer !== null) return;
+    sweepTimer = setInterval(sweepExpired, SWEEP_INTERVAL_MS);
+}
+
+function stopSweepTimer(): void {
+    if (sweepTimer !== null) {
+        clearInterval(sweepTimer);
+        sweepTimer = null;
+    }
+}
+
+startSweepTimer();
 
 export function getFromCache<T>(key: string): T | null {
     const entry = store.get(key) as CacheEntry<T> | undefined;
@@ -29,12 +44,13 @@ export function getFromCache<T>(key: string): T | null {
 
 export function setInCache<T>(key: string, value: T, ttlMs: number): void {
     if (!Number.isFinite(ttlMs) || ttlMs <= 0) return;
-    sweepExpired();
     store.set(key, { value, expiresAt: Date.now() + ttlMs });
 }
 
 export function clearCache(): void {
+    stopSweepTimer();
     store.clear();
+    startSweepTimer();
 }
 
 export function removeFromCache(key: string): void {

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -21,6 +21,7 @@ import {
     getChatStatus,
     getLifetimeTokens,
     getRecentChats,
+    invalidatePagesIndexed,
     type ChatItem,
 } from "../lib/api";
 
@@ -175,6 +176,18 @@ const Dashboard = () => {
 
         if (!updates.length) {
             return;
+        }
+
+        for (const update of updates) {
+            if (update.status !== "ready") continue;
+            const prevStatus = normalizeStatus(
+                chatProgressRef.current[update.id]?.status ||
+                    chatsRef.current.find((c) => c.id === update.id)?.status ||
+                    "",
+            );
+            if (prevStatus !== "ready") {
+                invalidatePagesIndexed(update.id);
+            }
         }
 
         setChatProgress((prev) => {


### PR DESCRIPTION
- In-memory Map cache with TTL support
- Stale-while-revalidate for allowlisted GET endpoints
- Cache invalidation on sign-out, API key/chat mutations, message send, and ingestion completion
- Cache keys scoped by user ID

Closes #20