### PR TITLE
added orderby to chatmessage.controller.js

### DIFF
--- a/backend/controllers/chatMessage.controller.js
+++ b/backend/controllers/chatMessage.controller.js
@@ -14,6 +14,7 @@ const memory = new MemoryClient({ apiKey: process.env.MEM0_API_KEY });
 const getAvailableModels = asyncHandler(async (req, res) => {
     const apikeys = await prisma.apiKey.findMany({
         where: { userId: req.user.id },
+        orderBy:{createdAt:"asc"}
     });
     if (!apikeys.length) {
         return res
@@ -43,6 +44,7 @@ const sendMessage = asyncHandler(async (req, res) => {
     const chat = await prisma.chat.findUnique({
         where: { id: chatId },
         include: { chatSources: true },
+        orderBy:{createdAt:"asc"}
     });
     if (!chat) {
         throw new ApiError(404, "Chat not found.");
@@ -67,6 +69,7 @@ const sendMessage = asyncHandler(async (req, res) => {
                 userId: req.user.id,
                 provider,
             },
+            orderBy: { createdAt: "asc" },
         });
         apiKeyId = apiKey.id;
 
@@ -99,6 +102,7 @@ const sendMessage = asyncHandler(async (req, res) => {
     } else {
         const docTree = await prisma.documentTree.findUnique({
             where: { id: chat.collectionName },
+            orderBy: { createdAt: "asc" },
         });
         treeindex.loadData(docTree.sourceData);
         treeindex.loadTree(docTree.treeData);
@@ -276,6 +280,7 @@ const exportChatMessages = asyncHandler(async (req, res) => {
 
     const chat = await prisma.chat.findUnique({
         where: { id: chatId },
+        orderBy: { createdAt: "asc" },
     });
 
     if (!chat || chat.userId !== req.user.id) {
@@ -285,6 +290,7 @@ const exportChatMessages = asyncHandler(async (req, res) => {
     const messages = await prisma.chatMessage.findMany({
         where: { chatId },
         orderBy: { createdAt: "asc" },
+
     });
 
     const escapeForPlainText = (text) => text || "";
@@ -340,6 +346,7 @@ const getChatMessages = asyncHandler(async (req, res) => {
 
     const chat = await prisma.chat.findUnique({
         where: { id: chatId },
+        orderBy: { createdAt: "asc" },
     });
 
     if (!chat || chat.userId !== req.user.id) {
@@ -348,6 +355,7 @@ const getChatMessages = asyncHandler(async (req, res) => {
 
     const messages = await prisma.chatMessage.findMany({
         where: { chatId },
+        orderBy: { createdAt: "asc" },
     });
 
     if (!messages.length) {
@@ -366,6 +374,7 @@ const getChatMessageSources = asyncHandler(async (req, res) => {
 
     const messageSources = await prisma.chatMessageSource.findMany({
         where: { chatMessageId: messageId },
+        orderBy: { createdAt: "asc" },
     });
 
     if (!messageSources.length) {


### PR DESCRIPTION
## Description

Fixes #33 

Messages were being returned in an unordered fashion from the backend, causing message pairs to appear out of order after a page refresh. This PR ensures messages are always returned sorted by `createdAt` ascending.

### Changes Made
- `backend/controllers/chatMessage.controller.js`: Added `orderBy: { createdAt: "asc" }` to the Prisma query

### Result
- Messages always appear in the correct chronological order
- Consistent UI rendering across refreshes

---

Let me know if any changes are needed! Happy to update. 🙂