### PR TITLE
fix(frontend): wrap localStorage in try/catch to prevent crashes

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -58,7 +58,13 @@ const isAccessTokenExpired = (token: string) => {
 };
 
 const getStoredSession = (): AuthSession | null => {
-    const raw = localStorage.getItem(AUTH_STORAGE_KEY);
+    let raw: string | null = null;
+    try {
+        raw = localStorage.getItem(AUTH_STORAGE_KEY);
+    } catch {
+        return null; // Ignore quota or security errors
+    }
+    
     if (!raw) return null;
 
     try {
@@ -67,23 +73,31 @@ const getStoredSession = (): AuthSession | null => {
 
         // Guard against stale or manually edited localStorage entries.
         if (!hasToken) {
-            localStorage.removeItem(AUTH_STORAGE_KEY);
+            try { localStorage.removeItem(AUTH_STORAGE_KEY); } catch {}
             return null;
         }
 
         return parsed as AuthSession;
     } catch {
-        localStorage.removeItem(AUTH_STORAGE_KEY);
+        try { localStorage.removeItem(AUTH_STORAGE_KEY); } catch {}
         return null;
     }
 };
 
 export const setAuthSession = (session: AuthSession) => {
-    localStorage.setItem(AUTH_STORAGE_KEY, JSON.stringify(session));
+    try {
+        localStorage.setItem(AUTH_STORAGE_KEY, JSON.stringify(session));
+    } catch {
+        // Ignore quota or security errors
+    }
 };
 
 export const clearAuthSession = () => {
-    localStorage.removeItem(AUTH_STORAGE_KEY);
+    try {
+        localStorage.removeItem(AUTH_STORAGE_KEY);
+    } catch {
+        // Ignore quota or security errors
+    }
 };
 
 export const forceSignOut = (redirectTo = "/signin") => {


### PR DESCRIPTION
﻿## What changed
* Added 	ry/catch wrappers around all localStorage.setItem, localStorage.getItem, and localStorage.removeItem calls in src/lib/auth.ts.

## Why
Calling the Web Storage API synchronously without error handling can throw synchronous exceptions (e.g., SecurityError, QuotaExceededError) in strict privacy modes (like Safari Private). Uncaught exceptions during React renders or module initialization cause the entire component tree to unmount, resulting in a blank white screen. This fix ensures that storage failures degrade gracefully without crashing the application.

## How to test
Run the frontend:
`ash id="t1x9ab"
pnpm run dev
`
Expected result:
* The frontend works normally. If you block cookies/storage via browser settings, the app still renders and operates normally instead of instantly throwing an uncaught exception.

## Screenshots (if UI change)
N/A 

## Related issue
Closes #92

---
## Pre-Submission Checklist
* [x] Branch named following GSSoC convention
* [x] Changes committed with meaningful commit message
* [x] Changes pushed to remote fork
* [x] Relevant tests executed successfully
* [x] Code follows project contribution guidelines
