### PR TITLE
fix(backend): prevent DoS by limiting scraper fetch payload size

### DIFF
--- a/backend/utils/ragUtilities.js
+++ b/backend/utils/ragUtilities.js
@@ -17,14 +17,44 @@ async function generateVectorEmbeddings(text) {
     return response.data[0].embedding;
 }
 
+const MAX_PAYLOAD_SIZE = 5 * 1024 * 1024; // 5MB limit
+
+async function safeFetchText(url) {
+    const response = await fetch(url);
+    if (!response.ok) {
+        throw new Error(`HTTP Error: ${response.status}`);
+    }
+
+    const contentType = response.headers.get("content-type") || "";
+    if (contentType && !contentType.includes("text/") && !contentType.includes("application/xml") && !contentType.includes("application/xhtml+xml")) {
+        throw new Error("Invalid content type. Only text-based documents are allowed.");
+    }
+
+    const chunks = [];
+    let size = 0;
+    
+    // In Node.js, fetch response.body is an async iterable of Uint8Arrays
+    if (response.body) {
+        for await (const chunk of response.body) {
+            size += chunk.length;
+            if (size > MAX_PAYLOAD_SIZE) {
+                throw new Error("Payload too large. Exceeded 5MB limit.");
+            }
+            chunks.push(chunk);
+        }
+    }
+    
+    return Buffer.concat(chunks).toString("utf-8");
+}
+
 async function scrapeTitle(url) {
-    const data = await (await fetch(url)).text();
+    const data = await safeFetchText(url);
     const $ = cheerio.load(data);
     return $("title").text();
 }
 
 async function scrapeWebpage(url = "", rootUrl = "") {
-    const data = await (await fetch(url)).text();
+    const data = await safeFetchText(url);
     const $ = cheerio.load(data);
 
     const rootHostname = new URL(rootUrl).hostname;


### PR DESCRIPTION
﻿## What changed
* Added safeFetchText helper in ackend/utils/ragUtilities.js.
* Modified scrapeWebpage and scrapeTitle to use safeFetchText instead of blindly buffering (await fetch(url)).text() into memory.
* The new fetch logic enforces a 5MB maximum payload size and validates that the Content-Type is a text-based document.

## Why
Calling etch(url).text() on user-provided URLs without size constraints creates an unconstrained resource consumption vulnerability (DoS). If a malicious actor inputs a URL that serves an infinite data stream or a massive multi-gigabyte file, the Node.js process attempts to buffer the entire payload into a single string. This rapidly exhausts the heap memory limit, crashing the backend API via an Out Of Memory (OOM) Panic. This fix ensures that oversized payloads are rejected and aborted before they can crash the server.

## How to test
Run the backend:
`ash id="t1x9ab"
pnpm run dev
`
Expected result:
* The RAG scraper works normally for regular documentation pages.
* Attempting to ingest a massive file (e.g., an ISO or a mock 10GB stream) throws a Payload too large. Exceeded 5MB limit. error and safely aborts the operation without crashing the API.

## Screenshots (if UI change)
N/A 

## Related issue
Closes #94

---
## Pre-Submission Checklist
* [x] Branch named following GSSoC convention
* [x] Changes committed with meaningful commit message
* [x] Changes pushed to remote fork
* [x] Relevant tests executed successfully
* [x] Code follows project contribution guidelines
