### PR TITLE
fix: block POST /message/send if chat is QUEUED, PROCESSING or FAILED

### DIFF
--- a/backend/controllers/chatMessage.controller.js
+++ b/backend/controllers/chatMessage.controller.js
@@ -48,6 +48,19 @@ const sendMessage = asyncHandler(async (req, res) => {
         throw new ApiError(404, "Chat not found.");
     }
 
+    if (chat.status === "QUEUED" || chat.status === "PROCESSING") {
+  throw new ApiError(
+    409,
+    "Chat is still indexing your docs — please try again in a moment."
+  );
+}
+
+if (chat.status === "FAILED") {
+  throw new ApiError(
+    409,
+    "Chat ingestion failed. Please re-ingest the documentation or check the docs URL and try again."
+  );
+}
     let openai;
     let modelId = model;
     let apiKeyId = null;

--- a/src/pages/ChatPage.tsx
+++ b/src/pages/ChatPage.tsx
@@ -414,15 +414,26 @@ export const ChatPage = () => {
                 );
             }
         } catch (err) {
-            if (chunkRafRef.current !== null) {
-                window.cancelAnimationFrame(chunkRafRef.current);
-                chunkRafRef.current = null;
-            }
-            pendingChunkRef.current = "";
-            setIsAwaitingFirstChunk(false);
-            setError(err instanceof Error ? err.message : "Failed to send message.");
-            setMessages((prev) => prev.filter((m) => m.id !== aiId));
-        } finally {
+    if (chunkRafRef.current !== null) {
+        window.cancelAnimationFrame(chunkRafRef.current);
+        chunkRafRef.current = null;
+    }
+    pendingChunkRef.current = "";
+    setIsAwaitingFirstChunk(false);
+
+    const errMsg = err instanceof Error ? err.message : "Failed to send message.";
+
+    // 409 = chat not ready or failed — show inline banner, restore input
+    if (err instanceof Error && (err.message.includes("indexing") || err.message.includes("ingestion"))) {
+        setError(errMsg);
+        setInput(newUserMessage.content);           // restore so user can retry
+        setMessages((prev) => prev.filter((m) => m.id !== aiId || m.id !== newUserMessage.id));
+    } else {
+        setError(errMsg);
+        setMessages((prev) => prev.filter((m) => m.id !== aiId));
+    }
+}
+        finally {
             setIsTyping(false);
         }
     };


### PR DESCRIPTION
## What
Blocks sendMessage if the chat status is QUEUED, PROCESSING, or FAILED.

## Why
If the chat isn't READY, vector mode may query a non-existent Qdrant 
collection and vectorless mode may have collectionName unset, leading 
to confusing failures.

## Changes
- `backend/controllers/chatMessage.controller.js` — added status check 
  after chat fetch, returns 409 with descriptive message
- `src/pages/ChatPage.tsx` — catch block handles 409, shows error 
  banner and restores user input for retry

Closes #72 