### PR TITLE
ci: add GitHub Actions workflow for lint and typecheck

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,55 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  frontend:
+    name: Frontend
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Install
+        run: pnpm install --frozen-lockfile
+
+      - name: Lint
+        run: pnpm lint
+
+      - name: Typecheck
+        run: pnpm typecheck
+
+  backend:
+    name: Backend
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+          cache-dependency-path: backend/pnpm-lock.yaml
+
+      - name: Install
+        working-directory: backend
+        run: pnpm install --frozen-lockfile
+
+      - name: Lint
+        working-directory: backend
+        run: pnpm lint

--- a/backend/package.json
+++ b/backend/package.json
@@ -4,7 +4,8 @@
     "description": "",
     "main": "index.js",
     "scripts": {
-        "dev": "node --watch index.js"
+        "dev": "node --watch index.js",
+        "lint": "node --check index.js && node --check app.js && node --check chatWorker.js"
     },
     "keywords": [],
     "author": "",

--- a/package.json
+++ b/package.json
@@ -3,10 +3,12 @@
     "private": true,
     "version": "0.0.0",
     "type": "module",
+    "packageManager": "pnpm@10.30.3",
     "scripts": {
         "dev": "vite",
         "build": "tsc -b && vite build",
         "lint": "eslint .",
+        "typecheck": "tsc -b",
         "preview": "vite preview"
     },
     "dependencies": {


### PR DESCRIPTION
## Summary

Adds a GitHub Actions CI workflow to validate frontend and backend changes on every pull request and push to `main`.

### Changes

* Added `.github/workflows/ci.yml`
* Added frontend `typecheck` script (`tsc -b`)
* Added backend syntax validation using `node --check`
* Configured pnpm dependency caching
* Split CI into separate frontend and backend jobs

## Testing

* Ran `pnpm lint`
* Ran `pnpm typecheck`
* Ran backend syntax validation with `pnpm lint`

Closes #84
