### PR TITLE
perf: add high-value indexes for chat, message and usage queries

### DIFF
--- a/backend/prisma/migrations/20260601_add_query_indexes/migration.sql
+++ b/backend/prisma/migrations/20260601_add_query_indexes/migration.sql
@@ -1,0 +1,4 @@
+CREATE INDEX "Chat_user_id_created_at_idx" ON "Chat"("user_id", "created_at");
+CREATE INDEX "Chat_status_created_at_idx" ON "Chat"("status", "created_at");
+CREATE INDEX "ChatMessage_chat_id_created_at_idx" ON "ChatMessage"("chat_id", "created_at");
+CREATE INDEX "UsageEvents_user_id_timestamp_idx" ON "UsageEvents"("user_id", "timestamp");

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -47,6 +47,9 @@ model Chat {
     chatSources    ChatSource[]  @relation("ChatToChatSource")
     messages       ChatMessage[]
     usageEvents    UsageEvents[]
+
+    @@index([userId, createdAt])
+    @@index([status, createdAt])
 }
 
 model ChatSource {
@@ -89,6 +92,8 @@ model ChatMessage {
     sourceChunks ChatMessageSource[]
     usageEvents  UsageEvents[]
     chat         Chat                @relation(fields: [chatId], references: [id])
+
+    @@index([chatId, createdAt])
 }
 
 model ChatMessageSource {
@@ -127,4 +132,6 @@ model UsageEvents {
     message      ChatMessage? @relation(fields: [messageId], references: [id], onDelete: SetNull)
     user         User         @relation(fields: [userId], references: [id])
     chat         Chat?        @relation(fields: [chatId], references: [id], onDelete: SetNull)
+
+    @@index([userId, timestamp])
 }


### PR DESCRIPTION
## Summary

Adds targeted database indexes for the most common query patterns used by chats, messages, and usage tracking.

### Indexes Added

* `Chat(userId, createdAt)`
* `Chat(status, createdAt)`
* `ChatMessage(chatId, createdAt)`
* `UsageEvents(userId, timestamp)`

### Rationale

* Accelerates chat listing queries by user and creation time
* Improves status-filtered chat queries
* Speeds up message retrieval within a chat ordered by creation time
* Optimizes usage event lookups by user and timestamp

### Validation

* `pnpm prisma validate` ✅
* `pnpm prisma generate` ✅

### EXPLAIN Verification

A local database instance was not available because `DATABASE_URL` was not configured in the development environment. Schema validation and migration SQL generation were completed successfully.

### Migration

Added migration SQL for the four indexes under:

`backend/prisma/migrations/20260601_add_query_indexes/migration.sql`

Closes #68
