### PR TITLE
fix: validate groupBy in usage analytics and remove SQL injection risk

### DIFF
--- a/backend/controllers/usage.controller.js
+++ b/backend/controllers/usage.controller.js
@@ -1,8 +1,7 @@
 import prisma from "../utils/prismaClient.js";
 import asyncHandler from "../utils/asyncHandler.js";
 import { ApiResponse } from "../utils/ApiResponse.js";
-import { ApiError } from "../utils/ApiError.js";
-import { Prisma } from "../generated/prisma/index.js";
+import { validateGroupBy } from "../utils/validationSchemas.js";
 
 const totalTokensUsedInLifetime = asyncHandler(async (req, res) => {
     const usage = await prisma.usageEvents.aggregate({
@@ -19,10 +18,46 @@ const totalTokensUsedInLifetime = asyncHandler(async (req, res) => {
 
 const tokensUsedByGroup = asyncHandler(async (req, res) => {
     const { groupBy } = req.params;
+    const { from, to } = req.query;
+
+    validateGroupBy(groupBy);
+
+    if (from && isNaN(Date.parse(from))) {
+        const err = new Error("Invalid 'from' date");
+        err.status = 400;
+        err.statusCode = 400;
+        throw err;
+    }
+
+    if (to && isNaN(Date.parse(to))) {
+        const err = new Error("Invalid 'to' date");
+        err.status = 400;
+        err.statusCode = 400;
+        throw err;
+    }
+
+    let truncUnit;
+    switch (groupBy) {
+        case "day":
+            truncUnit = "day";
+            break;
+        case "week":
+            truncUnit = "week";
+            break;
+        case "month":
+            truncUnit = "month";
+            break;
+        default: {
+            const err = new Error("Invalid groupBy");
+            err.status = 400;
+            err.statusCode = 400;
+            throw err;
+        }
+    }
 
     const usageByGroup = await prisma.$queryRaw`
         SELECT 
-            DATE_TRUNC(${Prisma.raw(`'${groupBy}'`)}, u."timestamp") AS period,
+            DATE_TRUNC(${truncUnit}, u."timestamp") AS period,
             m."llm_model" AS "model",
             SUM(u."input_tokens") AS "totalInput",
             SUM(u."output_tokens") AS "totalOutput"

--- a/backend/routers/usage.route.js
+++ b/backend/routers/usage.route.js
@@ -1,7 +1,7 @@
 import { Router } from "express";
 import { verifyStrictJWT } from "../middlewares/auth.middleware.js";
 import validate from "../middlewares/validate.middleware.js";
-import { tokensByGroupSchema } from "../utils/validationSchemas.js";
+import { VALID_GROUP_BY, tokensByGroupSchema } from "../utils/validationSchemas.js";
 import {
     tokensUsedByGroup,
     topChatsByTokensUsed,
@@ -10,8 +10,19 @@ import {
 
 const usageRouter = Router();
 
+function validateGroupByMiddleware(req, res, next) {
+    const { groupBy } = req.params;
+    if (!VALID_GROUP_BY.includes(groupBy)) {
+        return res.status(400).json({
+            error: `Invalid groupBy "${groupBy}". Must be one of: ${VALID_GROUP_BY.join(", ")}`,
+        });
+    }
+    next();
+}
+
 usageRouter.route("/lifetime-tokens").get(verifyStrictJWT, totalTokensUsedInLifetime);
-usageRouter.route("/tokens/:groupBy").get(verifyStrictJWT, validate(tokensByGroupSchema), tokensUsedByGroup);
+usageRouter.route("/group/:groupBy").get(verifyStrictJWT, validateGroupByMiddleware, tokensUsedByGroup);
+usageRouter.route("/tokens/:groupBy").get(verifyStrictJWT, validateGroupByMiddleware, validate(tokensByGroupSchema), tokensUsedByGroup);
 usageRouter.route("/top-chats").get(verifyStrictJWT, topChatsByTokensUsed);
 
 export default usageRouter;

--- a/backend/tests/usage.groupBy.test.js
+++ b/backend/tests/usage.groupBy.test.js
@@ -1,0 +1,96 @@
+import express from "express";
+import request from "supertest";
+import { jest } from "@jest/globals";
+
+const queryRawMock = jest.fn();
+const usageAggregateMock = jest.fn();
+const groupByMock = jest.fn();
+const chatFindManyMock = jest.fn();
+
+jest.unstable_mockModule("../utils/prismaClient.js", () => ({
+    default: {
+        $queryRaw: queryRawMock,
+        usageEvents: {
+            aggregate: usageAggregateMock,
+            groupBy: groupByMock,
+        },
+        chat: {
+            findMany: chatFindManyMock,
+        },
+    },
+}));
+
+jest.unstable_mockModule("../middlewares/auth.middleware.js", () => ({
+    verifyStrictJWT: (req, res, next) => {
+        req.user = { id: "test-user-id" };
+        next();
+    },
+    verifyJWT: (req, res, next) => next(),
+}));
+
+const { default: usageRouter } = await import("../routers/usage.route.js");
+
+const buildApp = () => {
+    const app = express();
+    app.use(express.json());
+    app.use("/api/v1/usage", usageRouter);
+    app.use((err, req, res, next) => {
+        res.status(err.statusCode || err.status || 500).json({ message: err.message });
+    });
+    return app;
+};
+
+beforeEach(() => {
+    queryRawMock.mockReset();
+    usageAggregateMock.mockReset();
+    groupByMock.mockReset();
+    chatFindManyMock.mockReset();
+});
+
+describe("usage groupBy route hardening", () => {
+    test.each(["day", "week", "month"])("GET /usage/group/%s returns 200", async (groupBy) => {
+        queryRawMock.mockResolvedValue([
+            {
+                period: new Date("2026-01-01T00:00:00.000Z"),
+                model: "gpt-4o",
+                totalInput: 12n,
+                totalOutput: 18n,
+            },
+        ]);
+
+        const app = buildApp();
+        const res = await request(app).get(`/api/v1/usage/group/${groupBy}`);
+
+        expect(res.status).toBe(200);
+        expect(Array.isArray(Object.values(res.body.data || {}))).toBe(true);
+        expect(queryRawMock).toHaveBeenCalledTimes(1);
+    });
+
+    test("GET /usage/group/year returns 400", async () => {
+        const app = buildApp();
+        const res = await request(app).get("/api/v1/usage/group/year");
+
+        expect(res.status).toBe(400);
+        expect(res.body.error || res.body.message).toMatch(/Invalid groupBy/i);
+        expect(queryRawMock).not.toHaveBeenCalled();
+    });
+
+    test("GET /usage/group/ returns 404 or 400", async () => {
+        const app = buildApp();
+        const res = await request(app).get("/api/v1/usage/group/");
+
+        expect([400, 404]).toContain(res.status);
+    });
+
+    test.each([
+        "1;DROP TABLE",
+        "%27%20OR%201=1",
+    ])("GET /usage/group/%s returns 400", async (rawGroupBy) => {
+        const app = buildApp();
+        const res = await request(app).get(`/api/v1/usage/group/${rawGroupBy}`);
+
+        expect(res.status).toBe(400);
+        expect(res.body.error || res.body.message).toMatch(/Invalid groupBy/i);
+        expect(queryRawMock).not.toHaveBeenCalled();
+    });
+});

--- a/backend/utils/validationSchemas.js
+++ b/backend/utils/validationSchemas.js
@@ -4,6 +4,17 @@ const email = z.string().trim().email("Invalid email address");
 const password = z.string().min(6, "Password must be at least 6 characters");
 const chatId = z.string().uuid("Invalid chat ID");
 const url = z.string().trim().url("Invalid URL");
+export const VALID_GROUP_BY = ["day", "week", "month"];
+
+export function validateGroupBy(value) {
+    if (!VALID_GROUP_BY.includes(value)) {
+        const err = new Error(`Invalid groupBy "${value}". Must be one of: ${VALID_GROUP_BY.join(", ")}`);
+        err.status = 400;
+        err.statusCode = 400;
+        throw err;
+    }
+    return value;
+}
 
 export const sendVerificationCodeSchema = {
     body: z.object({


### PR DESCRIPTION
## Fixes #65

### Summary

Implemented hardening for the usage analytics `groupBy` parameter by introducing strict allowlist validation (`day`, `week`, `month`) and removing the unsafe raw interpolation path.

### Changes

* Added `validateGroupBy` utility and allowlist validation.
* Validated `groupBy`, `from`, and `to` query parameters.
* Replaced dynamic truncation logic with a safe hardcoded mapping.
* Added `/group/:groupBy` route while maintaining backward compatibility for `/tokens/:groupBy`.
* Added Jest and Supertest coverage for valid, invalid, missing, and injection-like inputs.

### Testing

* ✅ 7/7 tests passing (`usage.groupBy.test.js`)
* ✅ Validated protection against invalid and injection-style inputs
