### PR TITLE
fix: handle missing API key without server crash

### DIFF
--- a/backend/controllers/chatMessage.controller.js
+++ b/backend/controllers/chatMessage.controller.js
@@ -68,11 +68,12 @@ const sendMessage = asyncHandler(async (req, res) => {
                 provider,
             },
         });
-        apiKeyId = apiKey.id;
+        
 
         if (!apiKey) {
             throw new ApiError(400, "Invalid API key ID.");
         }
+        apiKeyId = apiKey.id;
         if (apiKey.userId !== req.user.id) {
             throw new ApiError(403, "You do not have access to this API key.");
         }


### PR DESCRIPTION
issue : #27 

### Changes made

* Moved `apiKeyId = apiKey.id` after validating that `apiKey` exists
* Added proper handling for missing API key cases
* Prevented server crashes caused by accessing properties on null/undefined API keys

### Result

* Returns `400` when API key is missing
* No server crash when provider API key does not exist
* Prevents partial execution before validation

Please review it, and let me know if any changes are needed.

Thank you!
