### PR TITLE
feat: add safe cleanup for orphaned Qdrant collections

### DIFF
--- a/backend/controllers/chat.controller.js
+++ b/backend/controllers/chat.controller.js
@@ -3,6 +3,7 @@ import asyncHandler from "../utils/asyncHandler.js";
 import { ApiResponse } from "../utils/ApiResponse.js";
 import { ApiError } from "../utils/ApiError.js";
 import { scrapeWebpage } from "../utils/ragUtilities.js";
+import { cleanupQdrantCollections } from "../utils/qdrantCleanup.js";
 import { Queue } from "bullmq";
 import redis from "../utils/redis.js";
 import crypto from "crypto";
@@ -236,6 +237,34 @@ const recentFailedIngestionRuns = asyncHandler(async (req, res) => {
     });
 
     res.status(200).json(new ApiResponse(200, { runs }, "Failed ingestion runs fetched successfully"));
+});
+
+const qdrantCleanup = asyncHandler(async (req, res) => {
+    const isAdmin =
+        process.env.ADMIN_USERNAME &&
+        req.user?.username &&
+        req.user.username === process.env.ADMIN_USERNAME;
+
+    if (!isAdmin) {
+        throw new ApiError(403, "Admin privileges required to run Qdrant cleanup.");
+    }
+
+    const { force, minAgeDays } = req.query;
+    const forceExecution = Boolean(force);
+    const cleanupResult = await cleanupQdrantCollections({
+        force: forceExecution,
+        minAgeDays: Number.isFinite(Number(minAgeDays)) ? Number(minAgeDays) : undefined,
+    });
+
+    res.status(200).json(
+        new ApiResponse(
+            200,
+            cleanupResult,
+            forceExecution
+                ? "Qdrant cleanup completed successfully"
+                : "Qdrant cleanup dry-run completed successfully",
+        ),
+    );
 });
 
 const listAllChats = asyncHandler(async (req, res) => {
@@ -552,6 +581,7 @@ export {
     createChat,
     progressStatus,
     recentFailedIngestionRuns,
+    qdrantCleanup,
     listAllChats,
     chatDetails,
     cancelProcessing,

--- a/backend/routers/chat.route.js
+++ b/backend/routers/chat.route.js
@@ -5,6 +5,7 @@ import {
     expectationQuerySchema,
     createChatSchema,
     chatIdParamSchema,
+    qdrantCleanupSchema,
 } from "../utils/validationSchemas.js";
 import {
     cancelProcessing,
@@ -20,12 +21,14 @@ import {
     toggleShare,
     getSharedChatDetails,
     forkSharedChat,
+    qdrantCleanup,
 } from "../controllers/chat.controller.js";
 
 const chatRouter = Router();
 
 chatRouter.route("/expectation").get(verifyStrictJWT, validate(expectationQuerySchema), expectation);
 chatRouter.route("/create").post(verifyStrictJWT, validate(createChatSchema), createChat);
+chatRouter.route("/qdrant-cleanup").get(verifyStrictJWT, validate(qdrantCleanupSchema), qdrantCleanup);
 chatRouter.route("/status/:chatId").get(verifyStrictJWT, validate(chatIdParamSchema), progressStatus);
 chatRouter.route("/ingestion-runs/failed").get(verifyStrictJWT, recentFailedIngestionRuns);
 chatRouter.route("/list").get(verifyStrictJWT, listAllChats);

--- a/backend/scripts/qdrant-cleanup.js
+++ b/backend/scripts/qdrant-cleanup.js
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+import "dotenv/config";
+import { cleanupQdrantCollections } from "../utils/qdrantCleanup.js";
+
+function parseArgs() {
+    const args = process.argv.slice(2);
+    const result = {
+        force: false,
+        minAgeDays: undefined,
+    };
+
+    for (const arg of args) {
+        if (arg === "--force" || arg === "-f") {
+            result.force = true;
+        }
+
+        if (arg.startsWith("--min-age-days=")) {
+            const value = Number(arg.split("=")[1]);
+            if (Number.isFinite(value) && value >= 0) {
+                result.minAgeDays = Math.floor(value);
+            }
+        }
+
+        if (arg === "--dry-run" || arg === "-d") {
+            result.force = false;
+        }
+    }
+
+    return result;
+}
+
+async function main() {
+    const { force, minAgeDays } = parseArgs();
+    const result = await cleanupQdrantCollections({ force, minAgeDays });
+    console.log(JSON.stringify(result, null, 2));
+    if (!force) {
+        console.log("Note: this was a dry-run. Pass --force or -f to delete orphaned collections.");
+    }
+}
+
+main().catch((error) => {
+    console.error("Qdrant cleanup failed:", error?.message || error);
+    process.exit(1);
+});

--- a/backend/utils/qdrantCleanup.js
+++ b/backend/utils/qdrantCleanup.js
@@ -1,0 +1,132 @@
+import prisma from "./prismaClient.js";
+import { qdrant } from "./ragClients.js";
+
+const DEFAULT_MIN_AGE_DAYS = Number.parseInt(process.env.QDRANT_CLEANUP_MIN_AGE_DAYS || "7", 10);
+const MS_PER_DAY = 1000 * 60 * 60 * 24;
+
+function parseTimestampFromCollectionName(collectionName) {
+    if (!collectionName || typeof collectionName !== "string") return null;
+    const match = collectionName.match(/-(\d{13})$/);
+    if (!match) return null;
+    const parsed = Number(match[1]);
+    if (!Number.isFinite(parsed)) return null;
+    const date = new Date(parsed);
+    if (Number.isNaN(date.getTime())) return null;
+    return parsed;
+}
+
+function getCollectionAge(collectionName) {
+    const createdAtMs = parseTimestampFromCollectionName(collectionName);
+    if (createdAtMs === null) {
+        return { isKnown: false, ageMs: null, createdAtMs: null };
+    }
+
+    const ageMs = Date.now() - createdAtMs;
+    if (ageMs < 0) {
+        return { isKnown: false, ageMs: null, createdAtMs: null };
+    }
+
+    return { isKnown: true, ageMs, createdAtMs };
+}
+
+async function getReferencedCollectionNames() {
+    const [chatRefs, sourceRefs] = await Promise.all([
+        prisma.chat.findMany({
+            where: { collectionName: { not: null } },
+            select: { collectionName: true },
+        }),
+        prisma.chatSource.findMany({
+            where: { collectionName: { not: null } },
+            select: { collectionName: true },
+        }),
+    ]);
+
+    const referenced = new Set();
+    for (const item of [...chatRefs, ...sourceRefs]) {
+        const collectionName = item.collectionName?.trim();
+        if (collectionName) referenced.add(collectionName);
+    }
+    return referenced;
+}
+
+function normalizeCollectionsResponse(response) {
+    if (!response) return [];
+    if (Array.isArray(response)) return response;
+    if (Array.isArray(response.collections)) return response.collections;
+    return [];
+}
+
+export async function cleanupQdrantCollections({ force = false, minAgeDays = DEFAULT_MIN_AGE_DAYS } = {}) {
+    const dryRun = !force;
+    const referencedCollectionNames = await getReferencedCollectionNames();
+
+    const response = await qdrant.getCollections();
+    const collections = normalizeCollectionsResponse(response);
+
+    const deleted = [];
+    const skipped = [];
+    const candidates = [];
+
+    for (const collection of collections) {
+        const collectionName = collection?.name?.trim();
+        if (!collectionName || typeof collectionName !== "string") {
+            skipped.push({ name: collection?.name, reason: "invalidCollectionName" });
+            continue;
+        }
+
+        if (referencedCollectionNames.has(collectionName)) {
+            skipped.push({ name: collectionName, reason: "referencedInDatabase" });
+            continue;
+        }
+
+        const age = getCollectionAge(collectionName);
+        const minAgeMs = minAgeDays * MS_PER_DAY;
+
+        if (!age.isKnown) {
+            skipped.push({ name: collectionName, reason: "unknownAge", message: "Unable to parse timestamp from collection name; skipping for safety." });
+            continue;
+        }
+
+        if (age.ageMs < minAgeMs) {
+            skipped.push({
+                name: collectionName,
+                reason: "tooYoung",
+                ageDays: Number((age.ageMs / MS_PER_DAY).toFixed(2)),
+                minAgeDays,
+            });
+            continue;
+        }
+
+        candidates.push({ name: collectionName, ageDays: Number((age.ageMs / MS_PER_DAY).toFixed(2)) });
+    }
+
+    for (const candidate of candidates) {
+        if (dryRun) {
+            skipped.push({ name: candidate.name, reason: "dryRun" });
+            continue;
+        }
+
+        try {
+            await qdrant.deleteCollection(candidate.name, { timeout: 60000 });
+            deleted.push({ name: candidate.name, ageDays: candidate.ageDays });
+        } catch (error) {
+            skipped.push({
+                name: candidate.name,
+                reason: "deleteFailed",
+                message: error?.message || String(error),
+            });
+        }
+    }
+
+    return {
+        timestamp: new Date().toISOString(),
+        dryRun,
+        force,
+        minAgeDays,
+        totalQdrantCollections: collections.length,
+        referencedCollections: referencedCollectionNames.size,
+        orphanedCandidates: candidates.length,
+        deleted,
+        skipped,
+    };
+}

--- a/backend/utils/validationSchemas.js
+++ b/backend/utils/validationSchemas.js
@@ -4,6 +4,7 @@ const email = z.string().trim().email("Invalid email address");
 const password = z.string().min(6, "Password must be at least 6 characters");
 const chatId = z.string().uuid("Invalid chat ID");
 const url = z.string().trim().url("Invalid URL");
+const DEFAULT_MIN_AGE_DAYS = 7;
 export const VALID_GROUP_BY = ["day", "week", "month"];
 
 export function validateGroupBy(value) {
@@ -116,6 +117,32 @@ export const createChatSchema = {
                 });
 
                 return z.NEVER;
+            }),
+    }),
+};
+
+export const qdrantCleanupSchema = {
+    query: z.object({
+        force: z
+            .union([z.boolean(), z.string(), z.number()])
+            .optional()
+            .transform((value) => {
+                if (value === undefined || value === null) return false;
+                if (typeof value === "boolean") return value;
+                if (typeof value === "number") return value === 1;
+                if (typeof value === "string") {
+                    const normalized = value.trim().toLowerCase();
+                    return ["true", "1", "yes", "on"].includes(normalized);
+                }
+                return false;
+            }),
+        minAgeDays: z
+            .union([z.number(), z.string()])
+            .optional()
+            .transform((value) => {
+                if (value === undefined || value === null || value === "") return DEFAULT_MIN_AGE_DAYS;
+                const parsed = Number(value);
+                return Number.isFinite(parsed) && parsed >= 0 ? Math.floor(parsed) : DEFAULT_MIN_AGE_DAYS;
             }),
     }),
 };


### PR DESCRIPTION
## Summary

Implements a safe garbage-collection mechanism for orphaned Qdrant collections.

## Changes

* Added Qdrant cleanup utility to detect orphaned collections.
* Added dry-run mode (default).
* Added forced cleanup mode for actual deletion.
* Added admin-only cleanup endpoint.
* Added CLI script for manual execution.
* Prevents deletion of collections still referenced by Chat or ChatSource.
* Skips collections with unknown age.
* Logs deleted and skipped collections.

## Safety Guarantees

* Dry-run enabled by default.
* Actual deletion requires explicit force mode.
* Referenced collections are never deleted.
* Collections with unknown age are skipped.
* Admin authorization required for endpoint execution.

## Validation

* Syntax validation passed for all modified files.
* Verified Qdrant API usage and collection reference fields.
* Cleanup script requires configured environment credentials (OpenAI/Qdrant/DB) and therefore could not be fully executed in the local environment.
* Route ordering verified to avoid conflicts with parameterized routes.

Closes #82
