### PR TITLE
fix(mem0): make Mem0 integration optional and non-fatal

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,12 @@ node chatWorker.js # Optional: Start the background worker for processing chat c
 
 ---
 
+## Optional Features
+
+- **Long-term Memory (Mem0):** DocChat supports storing long-term interaction history. This feature is automatically enabled if you configure the `MEM0_API_KEY` in your `.env` file. If omitted or if Mem0 calls fail, the chat will continue to function normally without long-term context tracking.
+
+---
+
 ## Limitations
 
 - Works best with static documentation websites

--- a/backend/controllers/chatMessage.controller.js
+++ b/backend/controllers/chatMessage.controller.js
@@ -2,14 +2,14 @@ import prisma from "../utils/prismaClient.js";
 import asyncHandler from "../utils/asyncHandler.js";
 import { ApiResponse } from "../utils/ApiResponse.js";
 import { ApiError } from "../utils/ApiError.js";
-import { LLM_MODELS, PROVIDERS_BASE_URLS } from "../utils/constants.js";
+import { LLM_MODELS, PROVIDERS_BASE_URLS, MEM0_ENABLED } from "../utils/constants.js";
 import OpenAI from "openai";
 import { qdrant, treeindex } from "../utils/ragClients.js";
 import { decryptApiKey } from "../utils/decrypt.js";
 import { generateVectorEmbeddings } from "../utils/ragUtilities.js";
 import { MemoryClient } from "mem0ai";
 
-const memory = new MemoryClient({ apiKey: process.env.MEM0_API_KEY });
+const memory = MEM0_ENABLED ? new MemoryClient({ apiKey: process.env.MEM0_API_KEY }) : null;
 
 const getAvailableModels = asyncHandler(async (req, res) => {
     const apikeys = await prisma.apiKey.findMany({
@@ -155,15 +155,21 @@ if (chat.status === "FAILED") {
 
     // Long-term Memory (Mem0)
     let memoryContext = "";
-    const memoryFetched = await memory.search(userPrompt, {
-        user_id: req.user.id,
-        limit: 5,
-    });
-    if (memoryFetched.length) {
-        memoryContext = "\n--- RELEVANT PAST USER FACTS ---\n";
-        memoryFetched.forEach((item) => {
-            memoryContext += `- ${item.memory}\n`;
-        });
+    if (MEM0_ENABLED && memory) {
+        try {
+            const memoryFetched = await memory.search(userPrompt, {
+                user_id: req.user.id,
+                limit: 5,
+            });
+            if (memoryFetched && memoryFetched.length) {
+                memoryContext = "\n--- RELEVANT PAST USER FACTS ---\n";
+                memoryFetched.forEach((item) => {
+                    memoryContext += `- ${item.memory}\n`;
+                });
+            }
+        } catch (error) {
+            console.error("Mem0 search error (non-fatal):", error.message);
+        }
     }
 
     // Messages Array for the LLM
@@ -228,16 +234,22 @@ if (chat.status === "FAILED") {
     }
 
     if (llmResponse.trim()) {
-        await memory.add(
-            [
-                { role: "user", content: userPrompt },
-                { role: "assistant", content: llmResponse },
-            ],
-            {
-                user_id: req.user.id,
-                custom_instructions: "Note: Store this interaction history for future reference.",
-            },
-        );
+        if (MEM0_ENABLED && memory) {
+            try {
+                await memory.add(
+                    [
+                        { role: "user", content: userPrompt },
+                        { role: "assistant", content: llmResponse },
+                    ],
+                    {
+                        user_id: req.user.id,
+                        custom_instructions: "Note: Store this interaction history for future reference.",
+                    },
+                );
+            } catch (error) {
+                console.error("Mem0 add error (non-fatal):", error.message);
+            }
+        }
 
         const chatMessage = await prisma.chatMessage.create({
             data: {

--- a/backend/utils/constants.js
+++ b/backend/utils/constants.js
@@ -24,3 +24,4 @@ export const PROVIDERS_BASE_URLS = {
     XAI: "https://api.xaicontrol.com/v1",
     OPENROUTER: "https://openrouter.ai/api/v1",
 };
+export const MEM0_ENABLED = Boolean(process.env.MEM0_API_KEY);


### PR DESCRIPTION
## Description
Resolves #78 

This PR makes the Mem0 long-term memory integration optional and ensures that any Mem0-related errors do not crash or degrade the core chat functionality. 

Previously, `MemoryClient` was instantiated unconditionally, and API errors (e.g., missing keys, network failures, or 401s) would break the chat flow. With this change, the core RAG chat works flawlessly in environments where Mem0 is not configured, such as local development, CI, or specific deployments.

## Changes Made
- **Feature Flag**: Added a `MEM0_ENABLED` flag in `backend/utils/constants.js` to determine if the `MEM0_API_KEY` is present.
- **Conditional Initialization**: `MemoryClient` in `chatMessage.controller.js` is now only instantiated if `MEM0_ENABLED` is true.
- **Error Handling**: Wrapped `memory.search()` and `memory.add()` operations in `try/catch` blocks. If Mem0 fails, the error is logged to the console (non-fatal), and the chat interaction continues successfully.
- **Documentation**: Updated `README.md` to clearly specify that Mem0 is an optional feature.

## Acceptance Criteria Met
- [x] If `MEM0_API_KEY` is missing, chat still works (no crashes).
- [x] If Mem0 calls fail (network, 401), chat still completes and stores messages.
- [x] Mem0 behavior is clearly documented (enabled/disabled conditions).

## Testing
- Tested chat generation locally **without** a `MEM0_API_KEY` defined in `.env`.
- Verified that responses stream normally and messages are stored in the database without any application crashes.
