### PR TITLE
feat: implement chat ownership verification and add controller docstr…

### DIFF
--- a/backend/controllers/chat.controller.js
+++ b/backend/controllers/chat.controller.js
@@ -188,7 +188,7 @@ const progressStatus = asyncHandler(async (req, res) => {
             errorMessage: true,
         },
     });
-    
+
     const redisData = await redis.get(chat.id.toString());
     const progress = redisData ? JSON.parse(redisData) : { status: "QUEUED", progress: 0 };
 
@@ -214,11 +214,11 @@ const recentFailedIngestionRuns = asyncHandler(async (req, res) => {
         where: allowAll
             ? { status: "FAILED" }
             : {
-                  status: "FAILED",
-                  chat: {
-                      userId: req.user.id,
-                  },
-              },
+                status: "FAILED",
+                chat: {
+                    userId: req.user.id,
+                },
+            },
         orderBy: { startedAt: "desc" },
         take: limit,
         select: {
@@ -443,7 +443,7 @@ const toggleShare = asyncHandler(async (req, res) => {
         where: { id: chatId },
     });
 
-    if (!chat || chat.userId !== req.user.id) {
+    if (!chat) {
         throw new ApiError(404, "Chat not found");
     }
 

--- a/backend/controllers/chat.controller.js
+++ b/backend/controllers/chat.controller.js
@@ -194,11 +194,7 @@ const progressStatus = asyncHandler(async (req, res) => {
     const progress = redisData ? JSON.parse(redisData) : { status: "QUEUED", progress: 0 };
 
     res.status(200).json(
-        new ApiResponse(
-            200,
-            { progress, latestIngestionRun },
-            "Progress fetched successfully",
-        ),
+        new ApiResponse(200, { progress, latestIngestionRun }, "Progress fetched successfully"),
     );
 });
 
@@ -215,11 +211,11 @@ const recentFailedIngestionRuns = asyncHandler(async (req, res) => {
         where: allowAll
             ? { status: "FAILED" }
             : {
-                status: "FAILED",
-                chat: {
-                    userId: req.user.id,
-                },
-            },
+                  status: "FAILED",
+                  chat: {
+                      userId: req.user.id,
+                  },
+              },
         orderBy: { startedAt: "desc" },
         take: limit,
         select: {
@@ -526,8 +522,8 @@ const forkSharedChat = asyncHandler(async (req, res) => {
             messages: {
                 include: {
                     sourceChunks: true,
-                }
-            }
+                },
+            },
         },
     });
 
@@ -543,9 +539,9 @@ const forkSharedChat = asyncHandler(async (req, res) => {
             status: "READY",
             userId: req.user.id,
             chatSources: {
-                connect: originalChat.chatSources.map(source => ({ id: source.id }))
-            }
-        }
+                connect: originalChat.chatSources.map((source) => ({ id: source.id })),
+            },
+        },
     });
 
     // Copy messages so the new user has the history
@@ -557,7 +553,7 @@ const forkSharedChat = asyncHandler(async (req, res) => {
                 llmResponse: msg.llmResponse,
                 llmModel: msg.llmModel,
                 createdAt: msg.createdAt,
-            }
+            },
         });
 
         if (msg.sourceChunks && msg.sourceChunks.length > 0) {
@@ -568,12 +564,14 @@ const forkSharedChat = asyncHandler(async (req, res) => {
                     pageUrl: chunk.pageUrl,
                     score: chunk.score,
                     chatMessageId: newMessage.id,
-                }))
+                })),
             });
         }
     }
 
-    res.status(200).json(new ApiResponse(200, { chatId: newChat.id }, "Chat successfully forked to your account"));
+    res.status(200).json(
+        new ApiResponse(200, { chatId: newChat.id }, "Chat successfully forked to your account"),
+    );
 });
 
 export {

--- a/backend/controllers/chatMessage.controller.js
+++ b/backend/controllers/chatMessage.controller.js
@@ -14,7 +14,7 @@ const memory = MEM0_ENABLED ? new MemoryClient({ apiKey: process.env.MEM0_API_KE
 const getAvailableModels = asyncHandler(async (req, res) => {
     const apikeys = await prisma.apiKey.findMany({
         where: { userId: req.user.id },
-        orderBy: { createdAt: "asc" }
+        orderBy: { createdAt: "asc" },
     });
     if (!apikeys.length) {
         return res
@@ -32,7 +32,7 @@ const getAvailableModels = asyncHandler(async (req, res) => {
     apikeys.map((key) => {
         models.push(...LLM_MODELS[key.provider]);
     });
-    Array.from(new Set(models)).sort()
+    Array.from(new Set(models)).sort();
 
     return res
         .status(200)
@@ -51,16 +51,13 @@ const sendMessage = asyncHandler(async (req, res) => {
     }
 
     if (chat.status === "QUEUED" || chat.status === "PROCESSING") {
-        throw new ApiError(
-            409,
-            "Chat is still indexing your docs — please try again in a moment."
-        );
+        throw new ApiError(409, "Chat is still indexing your docs — please try again in a moment.");
     }
 
     if (chat.status === "FAILED") {
         throw new ApiError(
             409,
-            "Chat ingestion failed. Please re-ingest the documentation or check the docs URL and try again."
+            "Chat ingestion failed. Please re-ingest the documentation or check the docs URL and try again.",
         );
     }
     let openai;
@@ -84,7 +81,6 @@ const sendMessage = asyncHandler(async (req, res) => {
             },
             orderBy: { createdAt: "asc" },
         });
-
 
         if (!apiKey) {
             throw new ApiError(400, "Invalid API key ID.");
@@ -145,8 +141,7 @@ const sendMessage = asyncHandler(async (req, res) => {
         relevantSources.points.forEach((point, index) => {
             sourceContext += `Source ${index + 1}:\n${point.payload.body}\n`;
         });
-    }
-    else if (relevantNodes.length) {
+    } else if (relevantNodes.length) {
         relevantNodes.forEach(({ data }, index) => {
             sourceContext += `Source ${index + 1}:\n${data}\n`;
         });
@@ -242,7 +237,8 @@ const sendMessage = asyncHandler(async (req, res) => {
                     ],
                     {
                         user_id: req.user.id,
-                        custom_instructions: "Note: Store this interaction history for future reference.",
+                        custom_instructions:
+                            "Note: Store this interaction history for future reference.",
                     },
                 );
             } catch (error) {
@@ -269,14 +265,13 @@ const sendMessage = asyncHandler(async (req, res) => {
                     score: Math.round(point.score * 100),
                 })),
             });
-        }
-        else if (relevantNodes.length) {
+        } else if (relevantNodes.length) {
             await prisma.chatMessageSource.createMany({
                 data: relevantNodes.map((node, index) => {
                     const nodeId = node.id || relevantNodeIds[index] || `idx-${index}`;
                     let fallbackHeading = "Vectorless Source";
                     if (node.data) {
-                        const firstLine = node.data.split('\n')[0].trim();
+                        const firstLine = node.data.split("\n")[0].trim();
                         fallbackHeading = firstLine.substring(0, 60);
                         if (firstLine.length > 60) fallbackHeading += "...";
                     }
@@ -325,7 +320,6 @@ const exportChatMessages = asyncHandler(async (req, res) => {
     const messages = await prisma.chatMessage.findMany({
         where: { chatId },
         orderBy: { createdAt: "asc" },
-
     });
 
     const escapeForPlainText = (text) => text || "";
@@ -451,4 +445,11 @@ const getSharedChatMessages = asyncHandler(async (req, res) => {
         .json(new ApiResponse(200, { messages: messages }, "Chat messages retrieved successfully."));
 });
 
-export { sendMessage, getAvailableModels, getChatMessages, getChatMessageSources, exportChatMessages, getSharedChatMessages };
+export {
+    sendMessage,
+    getAvailableModels,
+    getChatMessages,
+    getChatMessageSources,
+    exportChatMessages,
+    getSharedChatMessages,
+};

--- a/backend/controllers/chatMessage.controller.js
+++ b/backend/controllers/chatMessage.controller.js
@@ -14,7 +14,7 @@ const memory = new MemoryClient({ apiKey: process.env.MEM0_API_KEY });
 const getAvailableModels = asyncHandler(async (req, res) => {
     const apikeys = await prisma.apiKey.findMany({
         where: { userId: req.user.id },
-        orderBy:{createdAt:"asc"}
+        orderBy: { createdAt: "asc" }
     });
     if (!apikeys.length) {
         return res
@@ -45,25 +45,25 @@ const sendMessage = asyncHandler(async (req, res) => {
     const chat = await prisma.chat.findUnique({
         where: { id: chatId },
         include: { chatSources: true },
-        orderBy:{createdAt:"asc"}
+        orderBy: { createdAt: "asc" }
     });
     if (!chat) {
         throw new ApiError(404, "Chat not found.");
     }
 
     if (chat.status === "QUEUED" || chat.status === "PROCESSING") {
-  throw new ApiError(
-    409,
-    "Chat is still indexing your docs — please try again in a moment."
-  );
-}
+        throw new ApiError(
+            409,
+            "Chat is still indexing your docs — please try again in a moment."
+        );
+    }
 
-if (chat.status === "FAILED") {
-  throw new ApiError(
-    409,
-    "Chat ingestion failed. Please re-ingest the documentation or check the docs URL and try again."
-  );
-}
+    if (chat.status === "FAILED") {
+        throw new ApiError(
+            409,
+            "Chat ingestion failed. Please re-ingest the documentation or check the docs URL and try again."
+        );
+    }
     let openai;
     let modelId = model;
     let apiKeyId = null;
@@ -85,7 +85,7 @@ if (chat.status === "FAILED") {
             },
             orderBy: { createdAt: "asc" },
         });
-        
+
 
         if (!apiKey) {
             throw new ApiError(400, "Invalid API key ID.");
@@ -123,7 +123,7 @@ if (chat.status === "FAILED") {
         treeindex.loadTree(docTree.treeData);
 
         const relevantNodeIds = await treeindex.retrieveRelevantNodes(userPrompt);
-        if(relevantNodeIds.length == 0) {
+        if (relevantNodeIds.length == 0) {
             res.write("No relevant sources found, for this query");
             res.end();
             return;
@@ -298,7 +298,7 @@ const exportChatMessages = asyncHandler(async (req, res) => {
         orderBy: { createdAt: "asc" },
     });
 
-    if (!chat || chat.userId !== req.user.id) {
+    if (!chat) {
         throw new ApiError(404, "Chat not found.");
     }
 
@@ -364,7 +364,7 @@ const getChatMessages = asyncHandler(async (req, res) => {
         orderBy: { createdAt: "asc" },
     });
 
-    if (!chat || chat.userId !== req.user.id) {
+    if (!chat) {
         throw new ApiError(404, "Chat not found.");
     }
 

--- a/backend/middlewares/chat.middleware.js
+++ b/backend/middlewares/chat.middleware.js
@@ -3,11 +3,11 @@ import { ApiError } from "../utils/ApiError.js";
 
 /**
  * Middleware to verify if the currently authenticated user owns the requested chat.
- * 
+ *
  * It expects a `chatId` to be present in either `req.params` or `req.body`.
  * If the chat does not exist, it throws a 404 ApiError.
  * If the user does not own the chat, it throws a 403 ApiError.
- * 
+ *
  * @param {import("express").Request} req - Express request object.
  * @param {import("express").Response} res - Express response object.
  * @param {import("express").NextFunction} next - Express next middleware function.

--- a/backend/middlewares/chat.middleware.js
+++ b/backend/middlewares/chat.middleware.js
@@ -1,0 +1,43 @@
+import prisma from "../utils/prismaClient.js";
+import { ApiError } from "../utils/ApiError.js";
+
+/**
+ * Middleware to verify if the currently authenticated user owns the requested chat.
+ * 
+ * It expects a `chatId` to be present in either `req.params` or `req.body`.
+ * If the chat does not exist, it throws a 404 ApiError.
+ * If the user does not own the chat, it throws a 403 ApiError.
+ * 
+ * @param {import("express").Request} req - Express request object.
+ * @param {import("express").Response} res - Express response object.
+ * @param {import("express").NextFunction} next - Express next middleware function.
+ * @throws {ApiError} 400 if chatId is missing, 404 if chat is not found, or 403 if unauthorized.
+ */
+const verifyChatOwnership = async (req, res, next) => {
+    try {
+        const chatId = req.params?.chatId || req.body?.chatId;
+
+        if (!chatId) {
+            throw new ApiError(400, "Chat ID is missing in request.");
+        }
+
+        const chat = await prisma.chat.findUnique({
+            where: { id: chatId },
+            select: { userId: true },
+        });
+
+        if (!chat) {
+            throw new ApiError(404, "Chat not found.");
+        }
+
+        if (chat.userId !== req.user.id) {
+            throw new ApiError(403, "You do not have permission to access this chat.");
+        }
+
+        next();
+    } catch (error) {
+        next(error);
+    }
+};
+
+export { verifyChatOwnership };

--- a/backend/routers/chat.route.js
+++ b/backend/routers/chat.route.js
@@ -30,7 +30,9 @@ const chatRouter = Router();
 chatRouter.route("/expectation").get(verifyStrictJWT, validate(expectationQuerySchema), expectation);
 chatRouter.route("/create").post(verifyStrictJWT, validate(createChatSchema), createChat);
 chatRouter.route("/qdrant-cleanup").get(verifyStrictJWT, validate(qdrantCleanupSchema), qdrantCleanup);
-chatRouter.route("/status/:chatId").get(verifyStrictJWT, validate(chatIdParamSchema), verifyChatOwnership, progressStatus);
+chatRouter
+    .route("/status/:chatId")
+    .get(verifyStrictJWT, validate(chatIdParamSchema), verifyChatOwnership, progressStatus);
 chatRouter.route("/ingestion-runs/failed").get(verifyStrictJWT, recentFailedIngestionRuns);
 chatRouter.route("/list").get(verifyStrictJWT, listAllChats);
 chatRouter.route("/recent").get(verifyStrictJWT, recentChats);
@@ -38,11 +40,21 @@ chatRouter.route("/recent").get(verifyStrictJWT, recentChats);
 // Shared Chat Routes
 chatRouter.route("/shared/:shareToken").get(getSharedChatDetails);
 chatRouter.route("/shared/:shareToken/fork").post(verifyStrictJWT, forkSharedChat);
-chatRouter.route("/:chatId/share").post(verifyStrictJWT, validate(chatIdParamSchema), verifyChatOwnership, toggleShare);
+chatRouter
+    .route("/:chatId/share")
+    .post(verifyStrictJWT, validate(chatIdParamSchema), verifyChatOwnership, toggleShare);
 
-chatRouter.route("/:chatId").get(verifyStrictJWT, validate(chatIdParamSchema), verifyChatOwnership, chatDetails);
-chatRouter.route("/pages-indexed/:chatId").get(verifyStrictJWT, validate(chatIdParamSchema), verifyChatOwnership, listAllPagesIndexed);
-chatRouter.route("/:chatId").delete(verifyStrictJWT, validate(chatIdParamSchema), verifyChatOwnership, deleteChat);
-chatRouter.route("/cancel/:chatId").get(verifyStrictJWT, validate(chatIdParamSchema), verifyChatOwnership, cancelProcessing);
+chatRouter
+    .route("/:chatId")
+    .get(verifyStrictJWT, validate(chatIdParamSchema), verifyChatOwnership, chatDetails);
+chatRouter
+    .route("/pages-indexed/:chatId")
+    .get(verifyStrictJWT, validate(chatIdParamSchema), verifyChatOwnership, listAllPagesIndexed);
+chatRouter
+    .route("/:chatId")
+    .delete(verifyStrictJWT, validate(chatIdParamSchema), verifyChatOwnership, deleteChat);
+chatRouter
+    .route("/cancel/:chatId")
+    .get(verifyStrictJWT, validate(chatIdParamSchema), verifyChatOwnership, cancelProcessing);
 
 export default chatRouter;

--- a/backend/routers/chat.route.js
+++ b/backend/routers/chat.route.js
@@ -1,6 +1,7 @@
 import { Router } from "express";
 import { verifyStrictJWT } from "../middlewares/auth.middleware.js";
 import validate from "../middlewares/validate.middleware.js";
+import { verifyChatOwnership } from "../middlewares/chat.middleware.js";
 import {
     expectationQuerySchema,
     createChatSchema,
@@ -26,7 +27,7 @@ const chatRouter = Router();
 
 chatRouter.route("/expectation").get(verifyStrictJWT, validate(expectationQuerySchema), expectation);
 chatRouter.route("/create").post(verifyStrictJWT, validate(createChatSchema), createChat);
-chatRouter.route("/status/:chatId").get(verifyStrictJWT, validate(chatIdParamSchema), progressStatus);
+chatRouter.route("/status/:chatId").get(verifyStrictJWT, validate(chatIdParamSchema), verifyChatOwnership, progressStatus);
 chatRouter.route("/ingestion-runs/failed").get(verifyStrictJWT, recentFailedIngestionRuns);
 chatRouter.route("/list").get(verifyStrictJWT, listAllChats);
 chatRouter.route("/recent").get(verifyStrictJWT, recentChats);
@@ -34,11 +35,11 @@ chatRouter.route("/recent").get(verifyStrictJWT, recentChats);
 // Shared Chat Routes
 chatRouter.route("/shared/:shareToken").get(getSharedChatDetails);
 chatRouter.route("/shared/:shareToken/fork").post(verifyStrictJWT, forkSharedChat);
-chatRouter.route("/:chatId/share").post(verifyStrictJWT, validate(chatIdParamSchema), toggleShare);
+chatRouter.route("/:chatId/share").post(verifyStrictJWT, validate(chatIdParamSchema), verifyChatOwnership, toggleShare);
 
-chatRouter.route("/:chatId").get(verifyStrictJWT, validate(chatIdParamSchema), chatDetails);
-chatRouter.route("/pages-indexed/:chatId").get(verifyStrictJWT, validate(chatIdParamSchema), listAllPagesIndexed);
-chatRouter.route("/:chatId").delete(verifyStrictJWT, validate(chatIdParamSchema), deleteChat);
-chatRouter.route("/cancel/:chatId").get(verifyStrictJWT, validate(chatIdParamSchema), cancelProcessing);
+chatRouter.route("/:chatId").get(verifyStrictJWT, validate(chatIdParamSchema), verifyChatOwnership, chatDetails);
+chatRouter.route("/pages-indexed/:chatId").get(verifyStrictJWT, validate(chatIdParamSchema), verifyChatOwnership, listAllPagesIndexed);
+chatRouter.route("/:chatId").delete(verifyStrictJWT, validate(chatIdParamSchema), verifyChatOwnership, deleteChat);
+chatRouter.route("/cancel/:chatId").get(verifyStrictJWT, validate(chatIdParamSchema), verifyChatOwnership, cancelProcessing);
 
 export default chatRouter;

--- a/backend/routers/chatMessage.route.js
+++ b/backend/routers/chatMessage.route.js
@@ -19,10 +19,18 @@ import {
 const chatMessageRouter = Router();
 
 chatMessageRouter.route("/models").get(verifyStrictJWT, getAvailableModels);
-chatMessageRouter.route("/send").post(verifyStrictJWT, validate(sendMessageSchema), verifyChatOwnership, sendMessage);
-chatMessageRouter.route("/all/:chatId").get(verifyStrictJWT, validate(chatIdParamSchema), verifyChatOwnership, getChatMessages);
-chatMessageRouter.route("/sources/:messageId").get(verifyStrictJWT, validate(messageIdParamSchema), getChatMessageSources);
-chatMessageRouter.route("/export/:chatId").get(verifyStrictJWT, validate(chatIdParamSchema), verifyChatOwnership, exportChatMessages);
+chatMessageRouter
+    .route("/send")
+    .post(verifyStrictJWT, validate(sendMessageSchema), verifyChatOwnership, sendMessage);
+chatMessageRouter
+    .route("/all/:chatId")
+    .get(verifyStrictJWT, validate(chatIdParamSchema), verifyChatOwnership, getChatMessages);
+chatMessageRouter
+    .route("/sources/:messageId")
+    .get(verifyStrictJWT, validate(messageIdParamSchema), getChatMessageSources);
+chatMessageRouter
+    .route("/export/:chatId")
+    .get(verifyStrictJWT, validate(chatIdParamSchema), verifyChatOwnership, exportChatMessages);
 
 // Shared Chat Messages Route
 chatMessageRouter.route("/shared/:shareToken/messages").get(getSharedChatMessages);

--- a/backend/routers/chatMessage.route.js
+++ b/backend/routers/chatMessage.route.js
@@ -1,6 +1,7 @@
 import { Router } from "express";
 import { verifyStrictJWT } from "../middlewares/auth.middleware.js";
 import validate from "../middlewares/validate.middleware.js";
+import { verifyChatOwnership } from "../middlewares/chat.middleware.js";
 import {
     sendMessageSchema,
     chatIdParamSchema,
@@ -18,10 +19,10 @@ import {
 const chatMessageRouter = Router();
 
 chatMessageRouter.route("/models").get(verifyStrictJWT, getAvailableModels);
-chatMessageRouter.route("/send").post(verifyStrictJWT, validate(sendMessageSchema), sendMessage);
-chatMessageRouter.route("/all/:chatId").get(verifyStrictJWT, validate(chatIdParamSchema), getChatMessages);
+chatMessageRouter.route("/send").post(verifyStrictJWT, validate(sendMessageSchema), verifyChatOwnership, sendMessage);
+chatMessageRouter.route("/all/:chatId").get(verifyStrictJWT, validate(chatIdParamSchema), verifyChatOwnership, getChatMessages);
 chatMessageRouter.route("/sources/:messageId").get(verifyStrictJWT, validate(messageIdParamSchema), getChatMessageSources);
-chatMessageRouter.route("/export/:chatId").get(verifyStrictJWT, validate(chatIdParamSchema), exportChatMessages);
+chatMessageRouter.route("/export/:chatId").get(verifyStrictJWT, validate(chatIdParamSchema), verifyChatOwnership, exportChatMessages);
 
 // Shared Chat Messages Route
 chatMessageRouter.route("/shared/:shareToken/messages").get(getSharedChatMessages);

--- a/backend/tests/chat.middleware.test.js
+++ b/backend/tests/chat.middleware.test.js
@@ -1,0 +1,98 @@
+/**
+ * Test Suite for Chat Ownership Middleware
+ * 
+ * Verifies the authorization logic that ensures users can only access or modify
+ * chats that belong to them. This suite mocks Prisma and the ApiError class
+ * to ensure isolated unit testing.
+ */
+import { jest } from "@jest/globals";
+
+const findUniqueMock = jest.fn();
+
+jest.unstable_mockModule("../utils/prismaClient.js", () => ({
+    default: {
+        chat: {
+            findUnique: findUniqueMock,
+        },
+    },
+}));
+
+jest.unstable_mockModule("../utils/ApiError.js", () => ({
+    ApiError: class ApiError extends Error {
+        constructor(statusCode, message) {
+            super(message);
+            this.statusCode = statusCode;
+        }
+    },
+}));
+
+const { verifyChatOwnership } = await import("../middlewares/chat.middleware.js");
+
+describe("verifyChatOwnership middleware", () => {
+    let req;
+    let res;
+    let next;
+
+    beforeEach(() => {
+        req = {
+            params: {},
+            body: {},
+            user: { id: "user-123" },
+        };
+        res = {};
+        next = jest.fn();
+        findUniqueMock.mockReset();
+    });
+
+    test("should throw 400 if chatId is missing", async () => {
+        await verifyChatOwnership(req, res, next);
+        expect(next).toHaveBeenCalledTimes(1);
+        const error = next.mock.calls[0][0];
+        expect(error.statusCode).toBe(400);
+        expect(error.message).toBe("Chat ID is missing in request.");
+    });
+
+    test("should throw 404 if chat is not found", async () => {
+        req.params.chatId = "chat-123";
+        findUniqueMock.mockResolvedValue(null);
+
+        await verifyChatOwnership(req, res, next);
+        expect(next).toHaveBeenCalledTimes(1);
+        const error = next.mock.calls[0][0];
+        expect(error.statusCode).toBe(404);
+        expect(error.message).toBe("Chat not found.");
+    });
+
+    test("should throw 403 if chat belongs to another user", async () => {
+        req.params.chatId = "chat-123";
+        findUniqueMock.mockResolvedValue({ userId: "user-456" });
+
+        await verifyChatOwnership(req, res, next);
+        expect(next).toHaveBeenCalledTimes(1);
+        const error = next.mock.calls[0][0];
+        expect(error.statusCode).toBe(403);
+        expect(error.message).toBe("You do not have permission to access this chat.");
+    });
+
+    test("should call next() without error if user owns the chat", async () => {
+        req.params.chatId = "chat-123";
+        findUniqueMock.mockResolvedValue({ userId: "user-123" });
+
+        await verifyChatOwnership(req, res, next);
+        expect(next).toHaveBeenCalledTimes(1);
+        expect(next.mock.calls[0][0]).toBeUndefined(); // no error passed
+    });
+    
+    test("should extract chatId from req.body if not in params", async () => {
+        req.body.chatId = "chat-789";
+        findUniqueMock.mockResolvedValue({ userId: "user-123" });
+
+        await verifyChatOwnership(req, res, next);
+        expect(findUniqueMock).toHaveBeenCalledWith({
+            where: { id: "chat-789" },
+            select: { userId: true },
+        });
+        expect(next).toHaveBeenCalledTimes(1);
+        expect(next.mock.calls[0][0]).toBeUndefined();
+    });
+});

--- a/backend/tests/chat.middleware.test.js
+++ b/backend/tests/chat.middleware.test.js
@@ -1,6 +1,6 @@
 /**
  * Test Suite for Chat Ownership Middleware
- * 
+ *
  * Verifies the authorization logic that ensures users can only access or modify
  * chats that belong to them. This suite mocks Prisma and the ApiError class
  * to ensure isolated unit testing.
@@ -82,7 +82,7 @@ describe("verifyChatOwnership middleware", () => {
         expect(next).toHaveBeenCalledTimes(1);
         expect(next.mock.calls[0][0]).toBeUndefined(); // no error passed
     });
-    
+
     test("should extract chatId from req.body if not in params", async () => {
         req.body.chatId = "chat-789";
         findUniqueMock.mockResolvedValue({ userId: "user-123" });


### PR DESCRIPTION
# Description

This PR introduces a robust and centralized authorization mechanism to ensure users can only access or modify chats they own. Previously, ownership verification was missing on some endpoints (like `sendMessage`) and inconsistently applied across others. 

Fixes #76

**Key Changes:**
- **Added `verifyChatOwnership` middleware** to handle chat authorization centrally.
- **Secured Routes**: Applied the middleware to all relevant routes in `chat.route.js` and `chatMessage.route.js`.
- **Refactored Controllers**: Removed redundant ownership checks from controller logic .

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Refactoring (code cleanup and documentation)

# How Has This Been Tested?

- [x] **Unit Testing**: Created a dedicated Jest test suite (`backend/tests/chat.middleware.test.js`) which mocks Prisma to verify all authorization paths:
  - Validates rejection when `chatId` is missing (400).
  - Validates rejection when the chat does not exist (404).
  - Validates rejection when the chat belongs to a different user (403).
  - Confirms successful `next()` calls when the user owns the chat.
