### PR TITLE
fix(schema): enforce unique ChatSource to prevent duplicate creation …

### DIFF
--- a/backend/controllers/chat.controller.js
+++ b/backend/controllers/chat.controller.js
@@ -89,24 +89,47 @@ const createChat = asyncHandler(async (req, res) => {
     const { internalLinks, title } = await scrapeWebpage(docsUrl, docsUrl);
     name = name || title || "Untitled Chat";
 
-    const existingChatSource = await prisma.chatSource.findFirst({
-        where: {
-            documentationUrl: docsUrl,
-            isVectorLess: isVectorLessChat,
-        },
-        include: {
-            chats: { take: 1 },
-        },
-    });
+    let chatSource;
+    let isNew = false;
+    const collectionName = !isVectorLessChat ? `${name.replace(/\s+/g, "-")}-${Date.now()}` : null;
 
-    if (existingChatSource) {
+    try {
+        chatSource = await prisma.chatSource.create({
+            data: {
+                totalPages: internalLinks.length,
+                heading: name,
+                documentationUrl: docsUrl,
+                collectionName: collectionName,
+                isVectorLess: isVectorLessChat,
+            },
+        });
+        isNew = true;
+    } catch (error) {
+        if (error.code === "P2002") { // Unique constraint violation
+            chatSource = await prisma.chatSource.findUnique({
+                where: {
+                    documentationUrl_isVectorLess: {
+                        documentationUrl: docsUrl,
+                        isVectorLess: isVectorLessChat,
+                    },
+                },
+            });
+            if (!chatSource) {
+                throw new ApiError(500, "Failed to retrieve existing ChatSource after unique constraint violation.");
+            }
+        } else {
+            throw error; // Rethrow other errors
+        }
+    }
+
+    if (!isNew) {
         const chat = await prisma.chat.create({
             data: {
                 name,
-                collectionName: existingChatSource.collectionName,
+                collectionName: chatSource.collectionName,
                 chatSources: {
                     connect: {
-                        id: existingChatSource.id,
+                        id: chatSource.id,
                     },
                 },
                 status: "READY",
@@ -124,18 +147,13 @@ const createChat = asyncHandler(async (req, res) => {
                 ),
             );
     } else {
-        const collectionName = !isVectorLessChat ? `${name.replace(/\s+/g, "-")}-${Date.now()}` : null;
         const chat = await prisma.chat.create({
             data: {
                 name,
-                collectionName: collectionName,
+                collectionName: chatSource.collectionName,
                 chatSources: {
-                    create: {
-                        totalPages: internalLinks.length,
-                        heading: name,
-                        documentationUrl: docsUrl,
-                        collectionName: collectionName,
-                        isVectorLess: isVectorLessChat,
+                    connect: {
+                        id: chatSource.id,
                     },
                 },
                 status: "QUEUED",

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -72,6 +72,8 @@ model ChatSource {
     documentTree     DocumentTree?
     createdAt        DateTime       @default(now()) @map("created_at")
     ingestionRuns    IngestionRun[]
+
+    @@unique([documentationUrl, isVectorLess])
 }
 
 model IngestionRun {

--- a/backend/scripts/cleanupDuplicateChatSources.js
+++ b/backend/scripts/cleanupDuplicateChatSources.js
@@ -1,0 +1,103 @@
+import prisma from "../utils/prismaClient.js";
+
+async function cleanupDuplicateChatSources() {
+    console.log("Finding duplicate ChatSource records...");
+    
+    const duplicates = await prisma.$queryRaw`
+        SELECT "documentation_url", "is_vector_less", COUNT(*) as count
+        FROM "ChatSource"
+        GROUP BY "documentation_url", "is_vector_less"
+        HAVING COUNT(*) > 1;
+    `;
+
+    console.log(`Found ${duplicates.length} duplicate groups.`);
+
+    for (const group of duplicates) {
+        console.log(`Processing duplicates for: ${group.documentation_url} (isVectorLess: ${group.is_vector_less})`);
+
+        const chatSources = await prisma.chatSource.findMany({
+            where: {
+                documentationUrl: group.documentation_url,
+                isVectorLess: group.is_vector_less,
+            },
+            orderBy: {
+                createdAt: 'asc', // oldest first
+            },
+        });
+
+        // The first one is our canonical record
+        const canonical = chatSources[0];
+        const duplicatesToRemove = chatSources.slice(1);
+
+        for (const duplicate of duplicatesToRemove) {
+            console.log(`  Re-linking records from duplicate ID ${duplicate.id} to canonical ID ${canonical.id}`);
+
+            // Re-link Chats
+            await prisma.chat.updateMany({
+                where: {
+                    chatSources: {
+                        some: { id: duplicate.id }
+                    }
+                },
+                data: {
+                    // Note: updateMany cannot do relation connects in Prisma easily.
+                    // We need to fetch chats connected to this duplicate, connect to canonical, and disconnect from duplicate.
+                }
+            });
+
+            const affectedChats = await prisma.chat.findMany({
+                where: { chatSources: { some: { id: duplicate.id } } }
+            });
+            
+            for (const chat of affectedChats) {
+                await prisma.chat.update({
+                    where: { id: chat.id },
+                    data: {
+                        chatSources: {
+                            connect: { id: canonical.id },
+                            disconnect: { id: duplicate.id }
+                        }
+                    }
+                });
+            }
+
+            // Re-link DocumentPages
+            await prisma.documentPage.updateMany({
+                where: { chatSourceId: duplicate.id },
+                data: { chatSourceId: canonical.id },
+            });
+
+            // Re-link DocumentTree (if exists)
+            // DocumentTree has @unique on chatSourceId. If canonical already has one, we delete the duplicate's.
+            const duplicateTree = await prisma.documentTree.findUnique({ where: { chatSourceId: duplicate.id }});
+            if (duplicateTree) {
+                const canonicalTree = await prisma.documentTree.findUnique({ where: { chatSourceId: canonical.id }});
+                if (canonicalTree) {
+                    await prisma.documentTree.delete({ where: { id: duplicateTree.id }});
+                } else {
+                    await prisma.documentTree.update({
+                        where: { id: duplicateTree.id },
+                        data: { chatSourceId: canonical.id },
+                    });
+                }
+            }
+
+            // Re-link IngestionRun
+            await prisma.ingestionRun.updateMany({
+                where: { chatSourceId: duplicate.id },
+                data: { chatSourceId: canonical.id },
+            });
+
+            console.log(`  Deleting duplicate ChatSource ${duplicate.id}`);
+            await prisma.chatSource.delete({
+                where: { id: duplicate.id },
+            });
+        }
+    }
+
+    console.log("Cleanup complete!");
+}
+
+cleanupDuplicateChatSources()
+    .catch(console.error)
+    .finally(() => prisma.$disconnect());


### PR DESCRIPTION
## Description
Resolves #66 

This PR makes the `createChat` controller fully resilient to concurrency issues by enforcing database-level uniqueness on `ChatSource` records and properly handling race conditions during simultaneous requests. 

Previously, `createChat` checked for an existing `ChatSource` via `findFirst` and then attempted to `create` one if it didn't exist. Under concurrent requests for the same URL, this resulted in duplicate `ChatSource` rows being created.

## Changes Made
- **Schema Update (`schema.prisma`)**: Added a compound unique constraint `@@unique([documentationUrl, isVectorLess])` on the `ChatSource` model to guarantee database-level concurrency protection.
- **Controller Logic (`chat.controller.js`)**: 
  - Updated the `createChat` logic to attempt the creation of `ChatSource` directly.
  - If a concurrent request creates it first, the database throws a Unique Constraint Violation (`P2002`). The new logic catches this specific error, fetches the newly created `ChatSource`, and connects the user's `Chat` to it seamlessly.
- **Migration & Cleanup**: Added a one-time script (`backend/scripts/cleanupDuplicateChatSources.js`) to clean up any existing duplicate data in production or dev databases prior to running the Prisma migration.

## Acceptance Criteria Met
- [x] Prisma schema enforces uniqueness for `(documentationUrl, isVectorLess)`.
- [x] Concurrent create requests for the same docs URL and mode no longer create duplicate `ChatSource` rows.
- [x] New chats reliably connect to the existing `ChatSource` when one already exists (even if created milliseconds prior).
- [x] Existing data migration/cleanup strategy is provided.

## Testing / Migration Instructions
Before merging or deploying this branch, ensure your database is clean of duplicates:
1. Navigate to the backend directory: `cd backend`
2. Run the cleanup script: `node scripts/cleanupDuplicateChatSources.js`
3. Apply the Prisma migration: `npx prisma migrate dev --name unique_chat_source_docs_url`
