### PR TITLE
fix: return only safe fields in user profile response

### DIFF
--- a/backend/middlewares/auth.middleware.js
+++ b/backend/middlewares/auth.middleware.js
@@ -18,8 +18,8 @@ const verifyStrictJWT = async (req, res, next) => {
                 fullname: true,
                 username: true,
                 email: true,
-                apikeys: true,
-                refreshToken: true,
+               
+               
             },
         });
 


### PR DESCRIPTION
issue: #25 

## Changes Made

* Removed sensitive fields from the Prisma `select` query in `auth.middleware.js`.
* Only the following fields are now attached to `req.user`:

  * `id`
  * `fullname`
  * `username`
  * `email`

## Security Impact

This prevents sensitive information from being exposed through the `/api/v1/user/profile` endpoint, including:

* `refreshToken`
* API key records (`apikeys`)

## Result

The profile endpoint now returns only safe user information and no longer exposes sensitive authentication-related data.

please inform if there are any changes needed
