### PR TITLE
fix: prevent NaN token totals by coalescing null tokens to  0

### DIFF
--- a/backend/controllers/chat.controller.js
+++ b/backend/controllers/chat.controller.js
@@ -293,8 +293,8 @@ const listAllChats = asyncHandler(async (req, res) => {
     const chatsWithUsage = chats.map((chat) => {
         const totals = chat.usageEvents.reduce(
             (acc, curr) => {
-                acc.inputTokens += curr.inputTokens;
-                acc.outputTokens += curr.outputTokens;
+                acc.inputTokens += curr.inputTokens ?? 0;
+                acc.outputTokens += curr.outputTokens ?? 0;
                 return acc;
             },
             { inputTokens: 0, outputTokens: 0 },
@@ -342,8 +342,8 @@ const recentChats = asyncHandler(async (req, res) => {
     const chatsWithUsage = chats.map((chat) => {
         const totals = chat.usageEvents.reduce(
             (acc, curr) => {
-                acc.inputTokens += curr.inputTokens;
-                acc.outputTokens += curr.outputTokens;
+                acc.inputTokens += curr.inputTokens ?? 0;
+                acc.outputTokens += curr.outputTokens ?? 0;
                 return acc;
             },
             { inputTokens: 0, outputTokens: 0 },


### PR DESCRIPTION
## What
Fix NaN token totals in `listAllChats` and `recentChats`.

## Why
When `inputTokens` or `outputTokens` is `null` in a usage event,
`acc.inputTokens += null` produces `NaN`, which propagates through
the reduce and breaks dashboard stats and sorting.

## How
Used nullish coalescing (`?? 0`) so null token values contribute 0
instead of NaN.

Fixes #74