### PR TITLE
fix: harden chat status progress response

### DIFF
--- a/backend/controllers/chat.controller.js
+++ b/backend/controllers/chat.controller.js
@@ -164,11 +164,36 @@ const createChat = asyncHandler(async (req, res) => {
     }
 });
 
+const DEFAULT_PROGRESS = {
+    status: "QUEUED",
+    current: 0,
+    total: 0,
+    progress: 0,
+};
+
+const normalizeProgress = (progress = {}) => {
+    const data = progress && typeof progress === "object" ? progress : {};
+
+    return {
+        ...DEFAULT_PROGRESS,
+        ...data,
+        current: Number.isFinite(data.current) ? data.current : DEFAULT_PROGRESS.current,
+        total: Number.isFinite(data.total) ? data.total : DEFAULT_PROGRESS.total,
+        progress: Number.isFinite(data.progress) ? data.progress : DEFAULT_PROGRESS.progress,
+    };
+};
+
 const progressStatus = asyncHandler(async (req, res) => {
     const { chatId } = req.params;
 
-    const chat = await prisma.chat.findUnique({
-        where: { id: chatId },
+    const chat = await prisma.chat.findFirst({
+        where: {
+            id: chatId,
+            userId: req.user.id,
+        },
+        select: {
+            id: true,
+        },
     });
 
     if (!chat) {
@@ -176,7 +201,7 @@ const progressStatus = asyncHandler(async (req, res) => {
     }
 
     const latestIngestionRun = await prisma.ingestionRun.findFirst({
-        where: { chatId },
+        where: { chatId: chat.id },
         orderBy: { startedAt: "desc" },
         select: {
             id: true,
@@ -190,8 +215,8 @@ const progressStatus = asyncHandler(async (req, res) => {
         },
     });
 
-    const redisData = await redis.get(chat.id.toString());
-    const progress = redisData ? JSON.parse(redisData) : { status: "QUEUED", progress: 0 };
+    const redisData = await redis.get(chat.id);
+    const progress = normalizeProgress(redisData ? JSON.parse(redisData) : DEFAULT_PROGRESS);
 
     res.status(200).json(
         new ApiResponse(200, { progress, latestIngestionRun }, "Progress fetched successfully"),

--- a/backend/routers/chat.route.js
+++ b/backend/routers/chat.route.js
@@ -32,7 +32,7 @@ chatRouter.route("/create").post(verifyStrictJWT, validate(createChatSchema), cr
 chatRouter.route("/qdrant-cleanup").get(verifyStrictJWT, validate(qdrantCleanupSchema), qdrantCleanup);
 chatRouter
     .route("/status/:chatId")
-    .get(verifyStrictJWT, validate(chatIdParamSchema), verifyChatOwnership, progressStatus);
+    .get(verifyStrictJWT, validate(chatIdParamSchema), progressStatus);
 chatRouter.route("/ingestion-runs/failed").get(verifyStrictJWT, recentFailedIngestionRuns);
 chatRouter.route("/list").get(verifyStrictJWT, listAllChats);
 chatRouter.route("/recent").get(verifyStrictJWT, recentChats);

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -217,7 +217,14 @@ export const deleteChat = async (chatId: string) => {
 };
 
 export const getChatStatus = (chatId: string) =>
-    apiRequest<{ progress: { status: string; progress: number } }>(`/chat/status/${chatId}`, {
+    apiRequest<{
+        progress: {
+            status: string;
+            progress: number;
+            current: number;
+            total: number;
+        };
+    }>(`/chat/status/${chatId}`, {
         method: "GET",
     });
 


### PR DESCRIPTION
Closes #75

## Summary
- Return 404 when chat status is requested for a missing or non-owned chat.
- Add a canonical default progress payload with status, current, total, and progress.
- Update frontend status response typing to match the backend payload.

## Testing
- Checked missing chat returns 404.
- Checked non-owned chat returns 404.
- Checked owned chat with no Redis data returns full default progress payload.