### PR TITLE
Feat/delete user data

### DIFF
--- a/backend/controllers/chat.controller.js
+++ b/backend/controllers/chat.controller.js
@@ -293,8 +293,8 @@ const listAllChats = asyncHandler(async (req, res) => {
     const chatsWithUsage = chats.map((chat) => {
         const totals = chat.usageEvents.reduce(
             (acc, curr) => {
-                acc.inputTokens += curr.inputTokens;
-                acc.outputTokens += curr.outputTokens;
+                acc.inputTokens += curr.inputTokens ?? 0;
+                acc.outputTokens += curr.outputTokens ?? 0;
                 return acc;
             },
             { inputTokens: 0, outputTokens: 0 },
@@ -342,8 +342,8 @@ const recentChats = asyncHandler(async (req, res) => {
     const chatsWithUsage = chats.map((chat) => {
         const totals = chat.usageEvents.reduce(
             (acc, curr) => {
-                acc.inputTokens += curr.inputTokens;
-                acc.outputTokens += curr.outputTokens;
+                acc.inputTokens += curr.inputTokens ?? 0;
+                acc.outputTokens += curr.outputTokens ?? 0;
                 return acc;
             },
             { inputTokens: 0, outputTokens: 0 },

--- a/backend/controllers/user.controller.js
+++ b/backend/controllers/user.controller.js
@@ -311,6 +311,85 @@ const resetPassword = asyncHandler(async (req, res) => {
     res.status(200).json(new ApiResponse(200, { reset: true }, "Password reset successfully !!"));
 });
 
+const deleteMyData = asyncHandler(async (req, res) => {
+  const userId = req.user.id; // set by your auth middleware
+  const { confirm } = req.query;
+
+  // Acceptance criteria: require explicit confirmation flag
+  if (confirm !== "true") {
+    return res.status(400).json({
+      success: false,
+      message: 'Pass confirm=true as a query param to confirm deletion.',
+    });
+  }
+
+  try {
+    await prisma.$transaction(async (tx) => {
+      // 1. Delete ChatMessageSources (deepest dependency first)
+      await tx.chatMessageSource.deleteMany({
+        where: { chatMessage: { chat: { userId } } },
+      });
+
+      // 2. Delete ChatMessages
+      await tx.chatMessage.deleteMany({
+        where: { chat: { userId } },
+      });
+
+      // 3. Delete UsageEvents (onDelete: SetNull means we must handle these)
+      await tx.usageEvent.deleteMany({ where: { userId } });
+
+      // 4. Delete ApiKeys
+      await tx.apiKey.deleteMany({ where: { userId } });
+
+      // 5. Delete ChatSources that belong ONLY to this user's chats
+      //    Safe detach: only remove if no other user's chat references them
+      const userChatIds = (
+        await tx.chat.findMany({
+          where: { userId },
+          select: { id: true },
+        })
+      ).map((c) => c.id);
+
+      // Find ChatSource IDs used by this user's chats
+      const userChatSources = await tx.chatSource.findMany({
+        where: { chatId: { in: userChatIds } },
+        select: { id: true, docsUrl: true },
+      });
+
+      // Only delete ChatSources not referenced by any other chat
+      for (const cs of userChatSources) {
+        const otherChatCount = await tx.chat.count({
+          where: {
+            chatSources: { some: { docsUrl: cs.docsUrl } },
+            userId: { not: userId },
+          },
+        });
+        if (otherChatCount === 0) {
+          await tx.chatSource.delete({ where: { id: cs.id } });
+        }
+      }
+
+      // 6. Delete Chats
+      await tx.chat.deleteMany({ where: { userId } });
+    });
+
+    return res.status(200).json({
+      success: true,
+      message: 'All your data has been deleted.',
+    });
+  } catch (error) {
+    // Idempotent: if already deleted, return success
+    if (error.code === 'P2025') {
+      return res.status(200).json({
+        success: true,
+        message: 'Data already deleted or not found.',
+      });
+    }
+    console.error('deleteMyData error:', error);
+    return res.status(500).json({ success: false, message: 'Server error.' });
+  }
+});
+
 export {
     userRegister,
     userLogIn,
@@ -321,4 +400,5 @@ export {
     currentUserProfile,
     resetPassword,
     sendResetCode,
+    deleteMyData,
 };

--- a/backend/routers/user.route.js
+++ b/backend/routers/user.route.js
@@ -19,6 +19,7 @@ import {
     currentUserProfile,
     resetPassword,
     sendResetCode,
+    deleteMyData,
 } from "../controllers/user.controller.js";
 
 const userRouter = Router();
@@ -32,5 +33,6 @@ userRouter.route("/refresh-tokens").patch(verifyJWT, refreshTokens);
 userRouter.route("/profile").get(verifyStrictJWT, currentUserProfile);
 userRouter.route("/send-reset-code").post(validate(sendResetCodeSchema), sendResetCode);
 userRouter.route("/reset-password").patch(validate(resetPasswordSchema), resetPassword);
+userRouter.route("/delete-my-data").delete(verifyStrictJWT, deleteMyData);
 
 export default userRouter;

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -418,3 +418,6 @@ export const getSharedChatMessages = (shareToken: string) =>
 
 export const forkSharedChat = (shareToken: string) =>
     apiRequest<{ chatId: string }>(`/chat/shared/${shareToken}/fork`, { method: "POST" });
+
+export const deleteMyData = () =>
+    apiRequest<{ message: string }>("/user/delete-my-data?confirm=true", { method: "DELETE" });

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -1,9 +1,9 @@
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { Sidebar } from "../components/Sidebar";
-import { User, Mail, LogOut, Save, Key, CheckCircle2 } from "lucide-react";
-import { logoutUser } from "../lib/auth";
-import { getUserProfile } from "../lib/api";
+import { User, Mail, LogOut, Save, Key, CheckCircle2, Trash2 } from "lucide-react";
+import { logoutUser, forceSignOut } from "../lib/auth";
+import { getUserProfile, deleteMyData } from "../lib/api";
 
 const Profile = () => {
     const navigate = useNavigate();
@@ -14,6 +14,9 @@ const Profile = () => {
     const [saved, setSaved] = useState(false);
     const [showLogoutConfirm, setShowLogoutConfirm] = useState(false);
     const [error, setError] = useState("");
+    const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+    const [isDeleting, setIsDeleting] = useState(false);
+    const [deleteError, setDeleteError] = useState("");
 
     useEffect(() => {
         const loadProfile = async () => {
@@ -38,6 +41,19 @@ const Profile = () => {
             setSaved(true);
             setTimeout(() => setSaved(false), 2000);
         }, 800);
+    };
+
+    const handleDeleteData = async () => {
+        setIsDeleting(true);
+        setDeleteError("");
+        try {
+            await deleteMyData();
+            forceSignOut();
+        } catch (err) {
+            setDeleteError(err instanceof Error ? err.message : "Failed to delete data.");
+            setIsDeleting(false);
+            setShowDeleteConfirm(false);
+        }
     };
 
     const handleLogout = async () => {
@@ -149,6 +165,28 @@ const Profile = () => {
                         </div>
                     </section>
 
+                    {/* Danger Zone — Delete Data */}
+                    <section className="bg-red-500/3 border border-red-500/10 rounded-2xl p-6 md:p-8">
+                        <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4">
+                            <div>
+                                <p className="text-sm font-medium text-gray-200">Delete all my data</p>
+                                <p className="text-xs text-gray-500">
+                                    Permanently deletes your chats, messages, API keys, and usage history.
+                                </p>
+                            </div>
+                            <button
+                                onClick={() => setShowDeleteConfirm(true)}
+                                className="px-5 py-2 rounded-lg bg-red-500/10 hover:bg-red-500/20 border border-red-500/20 text-red-400 text-sm font-medium transition-colors flex items-center gap-2 shrink-0"
+                            >
+                                <Trash2 className="w-4 h-4" />
+                                Delete My Data
+                            </button>
+                        </div>
+                        {deleteError && (
+                            <p className="mt-3 text-xs text-red-400">{deleteError}</p>
+                        )}
+                    </section>
+
                     {/* Logout */}
                     <section className="bg-red-500/3 border border-red-500/10 rounded-2xl p-6 md:p-8">
                         <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4">
@@ -171,6 +209,45 @@ const Profile = () => {
                     </section>
                 </div>
             </main>
+
+            {/* Delete Data Confirmation Modal */}
+            {showDeleteConfirm && (
+                <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+                    <div
+                        className="absolute inset-0 bg-black/60 backdrop-blur-sm"
+                        onClick={() => !isDeleting && setShowDeleteConfirm(false)}
+                    />
+                    <div className="relative w-full max-w-sm bg-[#0b0b0f] border border-white/10 rounded-2xl shadow-2xl p-6 text-center">
+                        <div className="w-14 h-14 rounded-full bg-red-500/10 border border-red-500/20 flex items-center justify-center mx-auto mb-4">
+                            <Trash2 className="w-6 h-6 text-red-400" />
+                        </div>
+                        <h3 className="text-lg font-semibold mb-2">Delete all data?</h3>
+                        <p className="text-sm text-gray-400 mb-6">
+                            This will permanently delete all your chats, messages, API keys, and usage history. This cannot be undone.
+                        </p>
+                        <div className="flex gap-3">
+                            <button
+                                onClick={() => setShowDeleteConfirm(false)}
+                                disabled={isDeleting}
+                                className="flex-1 px-4 py-2 rounded-lg text-sm font-medium text-gray-400 hover:text-white bg-white/5 hover:bg-white/10 transition-colors disabled:opacity-50"
+                            >
+                                Cancel
+                            </button>
+                            <button
+                                onClick={handleDeleteData}
+                                disabled={isDeleting}
+                                className="flex-1 px-4 py-2 rounded-lg text-sm font-medium text-white bg-red-500 hover:bg-red-600 transition-colors disabled:opacity-50 flex items-center justify-center gap-2"
+                            >
+                                {isDeleting ? (
+                                    <div className="w-4 h-4 border-2 border-white/30 border-t-white rounded-full animate-spin" />
+                                ) : (
+                                    "Delete Everything"
+                                )}
+                            </button>
+                        </div>
+                    </div>
+                </div>
+            )}
 
             {/* Logout Confirmation Modal */}
             {showLogoutConfirm && (


### PR DESCRIPTION
## Summary
Implements the "Delete all user data" feature per issue #53 

## What changed
- `backend/controllers/user.controller.js` — new `deleteMyData` controller
- `backend/routers/user.route.js` — new DELETE route
- `src/lib/api.ts` — `deleteMyData()` typed helper
- `src/pages/Profile.tsx` — confirmation UI with loading/error states
- `src/lib/auth.ts` — `clearAuthTokens()` helper

## Acceptance criteria checklist
Deletes chats, messages, message sources, usage events
Detaches shared ChatSources safely (won't break other users)
Requires confirm=true flag
Profile screen has "Delete my data" with in-app confirmation (no window.confirm)
Shows loading state, disables actions while in-flight
On success: signs out + redirects to /signin
On failure: shows error, does NOT sign out
Idempotent (second call returns success)
Uses DB transaction for atomicity