### PR TITLE
feat(auth): harden auth cookies with explicit sameSite, maxAge, and path

### DIFF
--- a/backend/controllers/user.controller.js
+++ b/backend/controllers/user.controller.js
@@ -13,10 +13,16 @@ const resend = new Resend(process.env.RESEND_API_KEY);
 const AccessOptions = {
     httpOnly: true,
     secure: process.env.NODE_ENV === "production",
+    sameSite: "lax",
+    maxAge: 1 * 24 * 60 * 60 * 1000, // 1 day
+    path: "/",
 };
 const RefreshOptions = {
     httpOnly: true,
     secure: process.env.NODE_ENV === "production",
+    sameSite: "lax",
+    maxAge: 10 * 24 * 60 * 60 * 1000, // 10 days
+    path: "/",
 };
 
 const hashPassword = async (password) => {


### PR DESCRIPTION
## Description
Resolves #44 

This PR hardens the authentication cookies by explicitly defining `sameSite`, `maxAge`, and `path` properties. Previously, the lack of these properties left session behavior up to browser defaults, creating potential cross-browser inconsistencies and leaving the application unnecessarily vulnerable to CSRF risks.

## Changes Made
- **`backend/controllers/user.controller.js`**: 
  - Added `sameSite: "lax"` to both `AccessOptions` and `RefreshOptions` to provide sensible CSRF protection while preserving normal top-level navigation.
  - Added `maxAge` to strictly align cookie lifespans with token expiries (1 day for `accessToken`, 10 days for `refreshToken`).
  - Set `path: "/"` explicitly to guarantee the cookies are applied globally to all backend routes.
  - Because these options are defined globally, both the `userLogIn` and `userLogOut` controllers automatically inherit these precise path attributes, ensuring sessions are properly created and predictably cleared.

## Acceptance Criteria Met
- [x] `accessToken` and `refreshToken` cookies have explicit `sameSite: 'lax'` configurations.
- [x] Cookies set `maxAge` perfectly aligned with JWT token expiry limits.
- [x] Cookies set `path` explicitly to `/`.
- [x] Cookies maintain `httpOnly` and `secure` settings consistent with the environment (e.g., `production` vs `development`).
