### PR TITLE
fix: replace non-standard 452 status code with HTTP 401

### DIFF
--- a/backend/middlewares/auth.middleware.js
+++ b/backend/middlewares/auth.middleware.js
@@ -7,7 +7,7 @@ const verifyStrictJWT = async (req, res, next) => {
         const token = req.cookies?.accessToken || req.header("Authorization")?.replace("Bearer ", "");
 
         if (!token) {
-            throw new ApiError(452, "Unauthorised request");
+            throw new ApiError(401, "Unauthorised request");
         }
 
         const decodedToken = jwt.verify(token, process.env.ACCESS_TOKEN_SECRET);
@@ -23,13 +23,13 @@ const verifyStrictJWT = async (req, res, next) => {
             },
         });
 
-        if (!user) throw new ApiError(452, "Invalid Access Token");
+        if (!user) throw new ApiError(401, "Invalid Access Token");
 
         req.user = user;
         next();
     } catch (error) {
         if (error instanceof ApiError) next(error);
-        else next(new ApiError(452, "Your Access Token expired !"));
+        else next(new ApiError(401, "Your Access Token expired !"));
     }
 };
 


### PR DESCRIPTION
## Summary
Replaced all 3 occurrences of non-standard status code `452` 
with correct HTTP `401` in `verifyStrictJWT`.

## Changes Made
File: backend/middlewares/auth.middleware.js

- Missing token now returns 401 instead of 452
- Invalid/deleted user token now returns 401 instead of 452
- Expired or malformed token now returns 401 instead of 452

verifyJWT is unchanged — it has no status codes by design.

Closes #24