### PR TITLE
refactor(ui): use /message/models on ChatPage to build dropdown options

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -142,6 +142,7 @@ export const invalidateApiKeyCaches = () => {
     const prefix = cacheKey("");
     removeMatchingFromCache(`${prefix}/apikey/list`);
     removeMatchingFromCache(`${prefix}/apikey/count`);
+    removeMatchingFromCache(`${prefix}/message/models`);
 };
 
 export const invalidateChatCaches = () => {
@@ -239,7 +240,7 @@ export const getPagesIndexed = (chatId: string) =>
     );
 
 export const getAvailableModels = () =>
-    withCache(cacheKey("/message/models"), 24 * 60 * 60 * 1000, () =>
+    withCache(cacheKey("/message/models"), 5 * 60 * 1000, () =>
         apiRequest<{ models: string[] }>("/message/models", { method: "GET" }),
     );
 

--- a/src/pages/ChatPage.tsx
+++ b/src/pages/ChatPage.tsx
@@ -51,7 +51,7 @@ import "highlight.js/styles/atom-one-dark.css";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import {
-    getApiKeys,
+    getAvailableModels,
     getChatDetails,
     getChatMessages,
     getMessageSources,
@@ -102,6 +102,7 @@ export const ChatPage = () => {
     });
     const [modelOptions, setModelOptions] = useState<ModelOption[]>([]);
     const [selectedModel, setSelectedModel] = useState("");
+    const [hasApiKeys, setHasApiKeys] = useState(true);
     const [isPageLoading, setIsPageLoading] = useState(true);
     const [isMessagesLoading, setIsMessagesLoading] = useState(true);
     const [error, setError] = useState("");
@@ -165,10 +166,10 @@ export const ChatPage = () => {
         setIsMessagesLoading(true);
         setError("");
         try {
-            const [chatDetails, indexedPageData, apiKeyData, messageData] = await Promise.all([
+            const [chatDetails, indexedPageData, availableModelsData, messageData] = await Promise.all([
                 getChatDetails(chatId),
                 getPagesIndexed(chatId),
-                getApiKeys(),
+                getAvailableModels(),
                 getChatMessages(chatId),
             ]);
 
@@ -212,13 +213,27 @@ export const ChatPage = () => {
                 },
             ];
 
-            const dynamicModels = (apiKeyData.apiKeys || []).flatMap((key) =>
-                (key.models || []).map((model) => ({
-                    provider: key.provider,
+            const rawModels = availableModelsData?.models || [];
+            const uniqueModels = Array.from(new Set(rawModels)).sort();
+            setHasApiKeys(uniqueModels.length > 0);
+
+            const inferProvider = (m: string) => {
+                if (m.includes("/")) return "OPENROUTER";
+                if (m.includes("gpt")) return "OPENAI";
+                if (m.includes("claude")) return "ANTHROPIC";
+                if (m.includes("gemini")) return "GOOGLE";
+                if (m.includes("grok")) return "XAI";
+                return "OPENROUTER";
+            };
+
+            const dynamicModels = uniqueModels.map((model) => {
+                const provider = inferProvider(model);
+                return {
+                    provider,
                     model,
-                    label: `${model} (${key.provider})`,
-                })),
-            );
+                    label: `${model} (${provider})`,
+                };
+            });
 
             const options = [...defaultOptions, ...dynamicModels];
             setModelOptions(options);
@@ -660,6 +675,14 @@ export const ChatPage = () => {
                             </div>
                         </div>
                         <div className="flex items-center gap-2 sm:gap-3 shrink-0">
+                            {!hasApiKeys && (
+                                <button
+                                    onClick={() => navigate("/dashboard?tab=api-keys")}
+                                    className="hidden sm:inline-flex text-xs font-semibold text-accent-blue hover:text-accent-blue/80 hover:underline px-2 transition-colors"
+                                >
+                                    + Add API Key
+                                </button>
+                            )}
                             <div className="hidden sm:flex items-center mr-2">
                                 <div className="relative inline-flex items-center gap-2 rounded-xl border border-white/15 bg-linear-to-r from-white/5 to-white/2 px-2.5 py-1.5 shadow-inner shadow-black/30">
                                     <span className="text-[11px] tracking-wide uppercase text-gray-500 font-semibold">


### PR DESCRIPTION
## Description
Resolves #43

This PR refactors `ChatPage` to fetch the available models directly from the dedicated `/message/models` backend endpoint instead of fetching the user's raw API key records. This reduces the payload size, minimizes the surface area for exposing sensitive metadata, and properly separates concerns.

## Changes Made
- **`src/pages/ChatPage.tsx`**:
  - Swapped `getApiKeys()` for `getAvailableModels()`.
  - Added frontend deduplication (`Array.from(new Set(...))`) to ensure stable model lists, bypassing a known bug in the backend where models were occasionally duplicated.
  - Implemented an `inferProvider` helper. Since `/message/models` only returns an array of strings, this cleanly derives the `provider` required by `sendMessageStream` by reading the model string prefix (e.g., `openai/` maps to `OPENROUTER`, `gpt` maps to `OPENAI`).
  - Added a new `+ Add API Key` CTA link beside the model selector that appears seamlessly when no external models are available.
- **`src/lib/api.ts`**:
  - Updated `invalidateApiKeyCaches()` to explicitly bust the `/message/models` cache whenever an API key is created or deleted.
  - Reduced the `getAvailableModels()` cache TTL from 24 hours to 5 minutes to prevent stale model lists from lingering if keys are edited on other devices.

## Acceptance Criteria Met
- [x] `ChatPage` builds model options directly from `getAvailableModels()`.
- [x] When no models are returned (excluding defaults), the UI shows a clear CTA to go to Settings.
- [x] `ChatPage` no longer calls the API-keys endpoint.
- [x] The default hosted models remain unaffected and always available.
- [x] The response options are deduplicated and stable.
