### PR TITLE
fix: replace indexOf with index-based for loop in exportChatMessages

### DIFF
--- a/backend/controllers/chatMessage.controller.js
+++ b/backend/controllers/chatMessage.controller.js
@@ -312,8 +312,9 @@ const exportChatMessages = asyncHandler(async (req, res) => {
 
     res.write(header);
 
-    for (const msg of messages) {
-        const msgNumber = messages.indexOf(msg) + 1;
+   for (let i = 0; i < messages.length; i++) {
+        const msg = messages[i];
+        const msgNumber = i + 1;
 
         const userBlock = [
             "",


### PR DESCRIPTION
## Summary
Fixes O(n²) performance issue in exportChatMessages by replacing
messages.indexOf(msg) inside a loop with a standard for loop index.

## Problem
exportChatMessages called messages.indexOf(msg) on every iteration
of a forEach loop. Since indexOf scans the array linearly, this
resulted in O(n²) time complexity.

## Fix
Replaced forEach + indexOf pattern with a standard for loop
using index i directly.

## Testing
- Tested with 10-message and 100-message chats
- Numbers are sequential and correct in all cases
- No change in output format

Closes #73