### PR TITLE
Fix: disable edit mode by default on profile page

### DIFF
--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { Sidebar } from "../components/Sidebar";
-import { User, Mail, LogOut, Save, Key, CheckCircle2 } from "lucide-react";
+import { User, Mail, LogOut, Save, Key, CheckCircle2, Pencil, X } from "lucide-react";
 import { logoutUser } from "../lib/auth";
 import { getUserProfile } from "../lib/api";
 
@@ -14,6 +14,8 @@ const Profile = () => {
     const [saved, setSaved] = useState(false);
     const [showLogoutConfirm, setShowLogoutConfirm] = useState(false);
     const [error, setError] = useState("");
+    const [isEditing, setIsEditing] = useState(false);
+    const [editName, setEditName] = useState("");
 
     useEffect(() => {
         const loadProfile = async () => {
@@ -31,10 +33,23 @@ const Profile = () => {
         loadProfile();
     }, []);
 
+    const handleEdit = () => {
+        setEditName(name);
+        setIsEditing(true);
+        setSaved(false);
+    };
+
+    const handleCancel = () => {
+        setIsEditing(false);
+        setEditName("");
+    };
+
     const handleSave = () => {
         setIsSaving(true);
         setTimeout(() => {
+            setName(editName);
             setIsSaving(false);
+            setIsEditing(false);
             setSaved(true);
             setTimeout(() => setSaved(false), 2000);
         }, 800);
@@ -72,56 +87,81 @@ const Profile = () => {
                                     {isProfileLoading ? "Loading profile..." : email || "-"}
                                 </p>
                             </div>
+                            {!isEditing && (
+                                <button
+                                    onClick={handleEdit}
+                                    className="px-4 py-2 rounded-lg bg-white/5 hover:bg-white/10 border border-white/10 text-sm font-medium text-gray-300 hover:text-white transition-colors flex items-center gap-2"
+                                >
+                                    <Pencil className="w-3.5 h-3.5" />
+                                    Edit
+                                </button>
+                            )}
                         </div>
 
-                        {/* Form Fields */}
+                        {/* Profile Fields */}
                         <div className="space-y-5">
                             <div className="grid grid-cols-1 md:grid-cols-2 gap-5">
                                 <div className="space-y-1.5">
                                     <label className="text-sm font-medium text-gray-400 flex items-center gap-1.5">
                                         <User className="w-3.5 h-3.5" /> Display Name
                                     </label>
-                                    <input
-                                        type="text"
-                                        value={name}
-                                        onChange={(e) => setName(e.target.value)}
-                                        className="w-full bg-[#111] border border-white/10 rounded-lg px-4 py-2.5 text-sm text-white focus:outline-none focus:border-accent-blue/50 focus:ring-1 focus:ring-accent-blue/50 transition-all"
-                                    />
+                                    {isEditing ? (
+                                        <input
+                                            type="text"
+                                            value={editName}
+                                            onChange={(e) => setEditName(e.target.value)}
+                                            className="w-full bg-[#111] border border-white/10 rounded-lg px-4 py-2.5 text-sm text-white focus:outline-none focus:border-accent-blue/50 focus:ring-1 focus:ring-accent-blue/50 transition-all"
+                                        />
+                                    ) : (
+                                        <p className="w-full bg-[#111]/50 border border-white/5 rounded-lg px-4 py-2.5 text-sm text-gray-300">
+                                            {name || "-"}
+                                        </p>
+                                    )}
                                 </div>
                                 <div className="space-y-1.5">
                                     <label className="text-sm font-medium text-gray-400 flex items-center gap-1.5">
                                         <Mail className="w-3.5 h-3.5" /> Email
                                     </label>
-                                    <input
-                                        type="email"
-                                        value={email}
-                                        disabled
-                                        className="w-full bg-[#111] border border-white/10 rounded-lg px-4 py-2.5 text-sm text-gray-500 focus:outline-none disabled:opacity-50 disabled:cursor-not-allowed"
-                                    />
+                                    <p className="w-full bg-[#111]/50 border border-white/5 rounded-lg px-4 py-2.5 text-sm text-gray-500">
+                                        {email || "-"}
+                                    </p>
                                 </div>
                             </div>
 
-                            <div className="flex items-center justify-end pt-2">
-                                <button
-                                    onClick={handleSave}
-                                    disabled={isSaving}
-                                    className="px-5 py-2 rounded-lg bg-accent-blue hover:bg-blue-600 disabled:opacity-60 text-white text-sm font-medium transition-all flex items-center gap-2 shadow-lg shadow-accent-blue/20"
-                                >
-                                    {isSaving ? (
-                                        <div className="w-4 h-4 border-2 border-white/30 border-t-white rounded-full animate-spin" />
-                                    ) : saved ? (
-                                        <>
-                                            <CheckCircle2 className="w-4 h-4 text-green-300" />
-                                            Saved!
-                                        </>
-                                    ) : (
-                                        <>
-                                            <Save className="w-4 h-4" />
-                                            Save Changes
-                                        </>
-                                    )}
-                                </button>
-                            </div>
+                            {isEditing && (
+                                <div className="flex items-center justify-end gap-3 pt-2">
+                                    <button
+                                        onClick={handleCancel}
+                                        className="px-4 py-2 rounded-lg bg-white/5 hover:bg-white/10 border border-white/10 text-sm font-medium text-gray-400 hover:text-white transition-colors flex items-center gap-2"
+                                    >
+                                        <X className="w-4 h-4" />
+                                        Cancel
+                                    </button>
+                                    <button
+                                        onClick={handleSave}
+                                        disabled={isSaving}
+                                        className="px-5 py-2 rounded-lg bg-accent-blue hover:bg-blue-600 disabled:opacity-60 text-white text-sm font-medium transition-all flex items-center gap-2 shadow-lg shadow-accent-blue/20"
+                                    >
+                                        {isSaving ? (
+                                            <div className="w-4 h-4 border-2 border-white/30 border-t-white rounded-full animate-spin" />
+                                        ) : (
+                                            <>
+                                                <Save className="w-4 h-4" />
+                                                Save Changes
+                                            </>
+                                        )}
+                                    </button>
+                                </div>
+                            )}
+
+                            {!isEditing && saved && (
+                                <div className="flex items-center justify-end pt-2">
+                                    <span className="text-sm text-green-400 flex items-center gap-1.5">
+                                        <CheckCircle2 className="w-4 h-4" />
+                                        Changes saved successfully
+                                    </span>
+                                </div>
+                            )}
                         </div>
                     </section>
 


### PR DESCRIPTION
## Description

Closes #133

### Problem

The Profile Settings page loads with the Display Name field in edit mode. The input is active and the **Save Changes** button is visible immediately, without the user explicitly choosing to edit.

### Fix

Updated the Profile component so that it loads in read-only mode by default. Users must click **Edit** to enter edit mode and can either **Save Changes** or **Cancel** to exit.

### Changes Made

**File:** `src/pages/Profile.tsx`

* Added `isEditing` state (default: `false`).
* Added `editName` state to store edits before saving.
* Added an **Edit** button (pencil icon) in the profile header.
* Display Name is shown as read-only text by default and becomes an input only when editing.
* Changed Email from a disabled input to read-only text for consistency.
* Added a **Cancel** button to discard changes and exit edit mode.
* **Save Changes** is only shown while editing.
* Added a **Changes saved successfully** confirmation message after saving.

### Before

* Display Name field was editable on page load.
* Save Changes button was always visible.
* No way to cancel edits.
* Email displayed as a disabled input field.

### After

* Profile loads in read-only mode.
* Edit mode starts only after clicking **Edit**.
* Cancel button allows users to discard changes.
* Save Changes appears only during editing.
* Email is displayed as read-only text.

### Screenshots
<p align="center">
  <img src="https://github.com/user-attachments/assets/f5ae9a40-caae-41a4-ad56-29373c28e91a" width="32%" />
  <img src="https://github.com/user-attachments/assets/1da9e961-e1b2-4818-9264-1025a102b6b9" width="32%" />
  <img src="https://github.com/user-attachments/assets/791a6ec9-288b-4de2-91f4-0aab085ced88" width="32%" />
</p>

### Additional Context

* No new dependencies added.
* No backend changes required.
* Submitted under SSoC.
