### PR TITLE
Add rate-limited crawl queue

### DIFF
--- a/backend/chatWorker.js
+++ b/backend/chatWorker.js
@@ -30,13 +30,27 @@ function getErrorCode(err) {
     return "UNKNOWN_ERROR";
 }
 
+function readPositiveInt(value, fallback) {
+    const parsed = Number.parseInt(value, 10);
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function getWorkerConfig() {
+    return {
+        maxPagesPerJob: readPositiveInt(process.env.CRAWL_MAX_PAGES_PER_JOB, 300),
+        vectorlessBatchSize: readPositiveInt(process.env.CRAWL_VECTORLESS_BATCH_SIZE, 5),
+        workerConcurrency: readPositiveInt(process.env.CHAT_WORKER_CONCURRENCY, 1),
+    };
+}
+
 async function processVector(docsRootUrl, chatId, collectionName, chatSourceId) {
     try {
+        const { maxPagesPerJob } = getWorkerConfig();
         const rootUrl = normalizeUrl(docsRootUrl);
         console.log("Scraping root:", rootUrl);
 
         const { internalLinks } = await scrapeWebpage(rootUrl, rootUrl);
-        let allLinks = internalLinks.slice(0, 300); // slice 5 - Just for development, slice 300 for production
+        let allLinks = internalLinks.slice(0, maxPagesPerJob);
         const totalLinks = allLinks.length;
 
         console.log("Total unique links found:", totalLinks);
@@ -149,23 +163,24 @@ async function processVector(docsRootUrl, chatId, collectionName, chatSourceId) 
 
 async function processVectorLess(docsRootUrl, chatId, chatSourceId) {
     try {
+        const { maxPagesPerJob, vectorlessBatchSize } = getWorkerConfig();
         await redis.setex(chatId, 3600, JSON.stringify({ status: "PROCESSING", progress: 0 }));
 
         const rootUrl = normalizeUrl(docsRootUrl);
         console.log("Scraping root:", rootUrl);
 
         const { internalLinks } = await scrapeWebpage(rootUrl, rootUrl);
-        let allLinks = internalLinks.slice(0, 300); // slice 3 - Just for development, slice 300 for production
+        let allLinks = internalLinks.slice(0, maxPagesPerJob);
         const totalLinks = allLinks.length;
 
         console.log("Total unique links found:", totalLinks);
 
-        let batchLinks = allLinks.slice(0, 5);
+        let batchLinks = allLinks.slice(0, vectorlessBatchSize);
         let allData = "";
         let i = 0;
 
         while (batchLinks.length > 0) {
-            batchLinks = allLinks.slice(i, i + 5);
+            batchLinks = allLinks.slice(i, i + vectorlessBatchSize);
             const results = await Promise.all(
                 batchLinks.map(async (link) => {
                     if (!isValidDocUrl(link, rootUrl)) return "";
@@ -180,7 +195,18 @@ async function processVectorLess(docsRootUrl, chatId, chatSourceId) {
             );
 
             allData += results.join("");
-            i += 5;
+            i += vectorlessBatchSize;
+
+            await redis.setex(
+                chatId,
+                3600,
+                JSON.stringify({
+                    status: "PROCESSING",
+                    current: Math.min(i, totalLinks),
+                    total: totalLinks,
+                    progress: totalLinks ? Math.round((Math.min(i, totalLinks) / totalLinks) * 100) : 0,
+                }),
+            );
         }
 
         if (!allData.trim()) {
@@ -266,6 +292,7 @@ const worker = new Worker(
     },
     {
         connection: redis,
+        concurrency: getWorkerConfig().workerConcurrency,
         removeOnComplete: { count: 50 },
         removeOnFail: { count: 500 },
     },

--- a/backend/package.json
+++ b/backend/package.json
@@ -19,6 +19,7 @@
         "@prisma/client-runtime-utils": "^7.5.0",
         "@qdrant/js-client-rest": "^1.17.0",
         "bcrypt": "^6.0.0",
+        "bottleneck": "^2.19.5",
         "bullmq": "^5.71.1",
         "cheerio": "^1.2.0",
         "cookie-parser": "^1.4.7",
@@ -32,6 +33,7 @@
         "pg": "^8.20.0",
         "prisma": "^7.5.0",
         "resend": "^6.9.4",
+        "robots-parser": "^3.0.1",
         "treeindex": "^1.0.0",
         "uuid": "^13.0.0",
         "zod": "^4.4.3"

--- a/backend/pnpm-lock.yaml
+++ b/backend/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       bcrypt:
         specifier: ^6.0.0
         version: 6.0.0
+      bottleneck:
+        specifier: ^2.19.5
+        version: 2.19.5
       bullmq:
         specifier: ^5.71.1
         version: 5.71.1
@@ -68,6 +71,9 @@ importers:
       resend:
         specifier: ^6.9.4
         version: 6.9.4
+      robots-parser:
+        specifier: ^3.0.1
+        version: 3.0.1
       treeindex:
         specifier: ^1.0.0
         version: 1.0.0(ws@8.20.0)(zod@4.4.3)
@@ -559,6 +565,9 @@ packages:
 
   boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
+
+  bottleneck@2.19.5:
+    resolution: {integrity: sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -1744,6 +1753,10 @@ packages:
     resolution: {integrity: sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==}
     engines: {node: '>= 4'}
 
+  robots-parser@3.0.1:
+    resolution: {integrity: sha512-s+pyvQeIKIZ0dx5iJiQk1tPLJAWln39+MI5jtM8wnyws+G5azk+dMnMX0qfbqNetKKNgcWWOdi0sfm+FbQbgdQ==}
+    engines: {node: '>=10.0.0'}
+
   router@2.2.0:
     resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
     engines: {node: '>= 18'}
@@ -2028,9 +2041,6 @@ packages:
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
-  zod@4.3.6:
-    resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
-
   zod@4.4.3:
     resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
@@ -2257,8 +2267,8 @@ snapshots:
   '@mistralai/mistralai@1.15.1':
     dependencies:
       ws: 8.20.0
-      zod: 4.3.6
-      zod-to-json-schema: 3.25.2(zod@4.3.6)
+      zod: 4.4.3
+      zod-to-json-schema: 3.25.2(zod@4.4.3)
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -2657,6 +2667,8 @@ snapshots:
       - supports-color
 
   boolbase@1.0.0: {}
+
+  bottleneck@2.19.5: {}
 
   braces@3.0.3:
     dependencies:
@@ -3902,6 +3914,8 @@ snapshots:
 
   retry@0.13.1: {}
 
+  robots-parser@3.0.1: {}
+
   router@2.2.0:
     dependencies:
       debug: 4.4.3
@@ -4153,17 +4167,10 @@ snapshots:
       grammex: 3.1.12
       graphmatch: 1.1.1
 
-  zod-to-json-schema@3.25.2(zod@4.3.6):
-    dependencies:
-      zod: 4.3.6
-
   zod-to-json-schema@3.25.2(zod@4.4.3):
     dependencies:
       zod: 4.4.3
-    optional: true
 
   zod@3.25.76: {}
-
-  zod@4.3.6: {}
 
   zod@4.4.3: {}

--- a/backend/tests/ragUtilities.robots.test.js
+++ b/backend/tests/ragUtilities.robots.test.js
@@ -1,0 +1,84 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+    isUrlAllowedByRobots,
+    parseRobotsTxt,
+    resetCrawlStateForTests,
+    scheduleCrawl,
+} from "../utils/ragUtilities.js";
+
+function restoreEnv(name, value) {
+    if (value === undefined) {
+        delete process.env[name];
+    } else {
+        process.env[name] = value;
+    }
+}
+
+test("robots parser blocks disallowed paths and honors more specific allow rules", () => {
+    resetCrawlStateForTests();
+
+    const parser = parseRobotsTxt(
+        [
+            "User-agent: *",
+            "Disallow: /docs/private",
+            "Allow: /docs/private/public",
+        ].join("\n"),
+        "https://docs.example.com/robots.txt",
+    );
+
+    assert.equal(
+        isUrlAllowedByRobots("https://docs.example.com/docs/private/page", parser, "DocChatBot/1.0"),
+        false,
+    );
+    assert.equal(
+        isUrlAllowedByRobots("https://docs.example.com/docs/private/public/page", parser, "DocChatBot/1.0"),
+        true,
+    );
+});
+
+test("robots parser exposes crawl-delay for the configured worker user-agent", () => {
+    resetCrawlStateForTests();
+
+    const parser = parseRobotsTxt(
+        [
+            "User-agent: DocChatBot",
+            "Crawl-delay: 2.5",
+            "Disallow:",
+        ].join("\n"),
+        "https://docs.example.com/robots.txt",
+    );
+
+    assert.equal(parser.getCrawlDelay("DocChatBot/1.0"), 2.5);
+});
+
+test("crawl scheduler spaces requests for the same domain", async () => {
+    const previousRespectRobots = process.env.CRAWL_RESPECT_ROBOTS_TXT;
+    const previousDelay = process.env.CRAWL_DELAY_MS;
+    const previousConcurrency = process.env.CRAWL_MAX_CONCURRENCY_PER_DOMAIN;
+
+    process.env.CRAWL_RESPECT_ROBOTS_TXT = "false";
+    process.env.CRAWL_DELAY_MS = "30";
+    process.env.CRAWL_MAX_CONCURRENCY_PER_DOMAIN = "1";
+    resetCrawlStateForTests();
+
+    try {
+        const starts = [];
+        await Promise.all([
+            scheduleCrawl("https://93.184.216.34/a", async () => {
+                starts.push(Date.now());
+            }),
+            scheduleCrawl("https://93.184.216.34/b", async () => {
+                starts.push(Date.now());
+            }),
+        ]);
+
+        assert.equal(starts.length, 2);
+        assert.ok(starts[1] - starts[0] >= 25);
+    } finally {
+        restoreEnv("CRAWL_RESPECT_ROBOTS_TXT", previousRespectRobots);
+        restoreEnv("CRAWL_DELAY_MS", previousDelay);
+        restoreEnv("CRAWL_MAX_CONCURRENCY_PER_DOMAIN", previousConcurrency);
+        resetCrawlStateForTests();
+    }
+});

--- a/backend/utils/ragUtilities.js
+++ b/backend/utils/ragUtilities.js
@@ -1,14 +1,58 @@
 import * as cheerio from "cheerio";
 import OpenAI from "openai";
 import dns from "node:dns/promises";
+import Bottleneck from "bottleneck";
+import robotsParser from "robots-parser";
 
-const openai = new OpenAI({
-    baseURL: "https://openrouter.ai/api/v1",
-    apiKey: process.env.OPENROUTER_EMBEDDING_API_KEY,
-});
+const robotsCache = new Map();
+const domainLimiters = new Map();
+
+let openai;
+
+function getOpenAIClient() {
+    if (!process.env.OPENROUTER_EMBEDDING_API_KEY) {
+        throw new Error("OPENROUTER_EMBEDDING_API_KEY is required to generate vector embeddings.");
+    }
+
+    if (!openai) {
+        openai = new OpenAI({
+            baseURL: "https://openrouter.ai/api/v1",
+            apiKey: process.env.OPENROUTER_EMBEDDING_API_KEY,
+        });
+    }
+
+    return openai;
+}
+
+function readPositiveInt(value, fallback) {
+    const parsed = Number.parseInt(value, 10);
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function readNonNegativeInt(value, fallback) {
+    const parsed = Number.parseInt(value, 10);
+    return Number.isFinite(parsed) && parsed >= 0 ? parsed : fallback;
+}
+
+function readBoolean(value, fallback) {
+    if (value === undefined) return fallback;
+    return ["1", "true", "yes", "on"].includes(String(value).toLowerCase());
+}
+
+function getCrawlConfig() {
+    return {
+        userAgent: process.env.CRAWL_USER_AGENT || "DocChatBot/1.0",
+        respectRobotsTxt: readBoolean(process.env.CRAWL_RESPECT_ROBOTS_TXT, true),
+        defaultDelayMs: readNonNegativeInt(process.env.CRAWL_DELAY_MS, 1000),
+        maxConcurrencyPerDomain: readPositiveInt(process.env.CRAWL_MAX_CONCURRENCY_PER_DOMAIN, 2),
+        robotsTimeoutMs: readPositiveInt(process.env.CRAWL_ROBOTS_TIMEOUT_MS, 5000),
+        robotsCacheTtlMs: readPositiveInt(process.env.CRAWL_ROBOTS_CACHE_TTL_MS, 10 * 60 * 1000),
+        allowOnRobotsError: readBoolean(process.env.CRAWL_ALLOW_ON_ROBOTS_ERROR, false),
+    };
+}
 
 async function generateVectorEmbeddings(text) {
-    const response = await openai.embeddings.create({
+    const response = await getOpenAIClient().embeddings.create({
         model: "openai/text-embedding-3-small",
         input: text,
         encoding_format: "float",
@@ -104,16 +148,165 @@ async function validatePublicUrl(urlString) {
     }
 }
 
+function parseRobotsTxt(contents = "", robotsUrl = "https://example.com/robots.txt") {
+    return robotsParser(robotsUrl, contents);
+}
+
+function getRobotsCrawlDelayMs(parser, userAgent) {
+    const crawlDelaySeconds = parser.getCrawlDelay(userAgent);
+    return Number.isFinite(crawlDelaySeconds) && crawlDelaySeconds >= 0
+        ? Math.round(crawlDelaySeconds * 1000)
+        : null;
+}
+
+function isUrlAllowedByRobots(urlString, parser, userAgent = getCrawlConfig().userAgent) {
+    return parser.isAllowed(urlString, userAgent) !== false;
+}
+
+async function fetchTextWithTimeout(url, config) {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), config.robotsTimeoutMs);
+
+    try {
+        const response = await fetch(url, {
+            signal: controller.signal,
+            headers: {
+                "User-Agent": config.userAgent,
+            },
+        });
+
+        return response;
+    } finally {
+        clearTimeout(timeout);
+    }
+}
+
+async function fetchRobotsPolicy(origin, config) {
+    if (!config.respectRobotsTxt) {
+        return {
+            parser: parseRobotsTxt("", new URL("/robots.txt", origin).toString()),
+            crawlDelayMs: null,
+            failureReason: null,
+        };
+    }
+
+    const robotsUrl = new URL("/robots.txt", origin).toString();
+
+    try {
+        await validatePublicUrl(robotsUrl);
+        const response = await fetchTextWithTimeout(robotsUrl, config);
+
+        if (response.status === 404) {
+            return { parser: parseRobotsTxt("", robotsUrl), crawlDelayMs: null, failureReason: null };
+        }
+
+        if (!response.ok) {
+            const failureReason = `robots.txt returned HTTP ${response.status}`;
+            if (!config.allowOnRobotsError) {
+                return { parser: parseRobotsTxt("", robotsUrl), crawlDelayMs: null, failureReason };
+            }
+            return { parser: parseRobotsTxt("", robotsUrl), crawlDelayMs: null, failureReason: null };
+        }
+
+        const parser = parseRobotsTxt(await response.text(), robotsUrl);
+        return {
+            parser,
+            crawlDelayMs: getRobotsCrawlDelayMs(parser, config.userAgent),
+            failureReason: null,
+        };
+    } catch (error) {
+        if (config.allowOnRobotsError) {
+            return { parser: parseRobotsTxt("", robotsUrl), crawlDelayMs: null, failureReason: null };
+        }
+        return {
+            parser: parseRobotsTxt("", robotsUrl),
+            crawlDelayMs: null,
+            failureReason: `robots.txt check failed: ${error.message}`,
+        };
+    }
+}
+
+async function getRobotsPolicy(urlString, config) {
+    const origin = new URL(urlString).origin;
+    const cacheKey = `${origin}|${config.userAgent}`;
+    const cached = robotsCache.get(cacheKey);
+
+    if (cached && cached.expiresAt > Date.now()) {
+        return cached.promise;
+    }
+
+    const promise = fetchRobotsPolicy(origin, config);
+    robotsCache.set(cacheKey, {
+        expiresAt: Date.now() + config.robotsCacheTtlMs,
+        promise,
+    });
+
+    return promise;
+}
+
+function getDomainLimiter(urlString, config, crawlDelayMs) {
+    const hostname = new URL(urlString).hostname.toLowerCase();
+    if (!domainLimiters.has(hostname)) {
+        domainLimiters.set(hostname, new Bottleneck({
+            maxConcurrent: config.maxConcurrencyPerDomain,
+            minTime: crawlDelayMs,
+        }));
+    } else {
+        domainLimiters.get(hostname).updateSettings({
+            maxConcurrent: config.maxConcurrencyPerDomain,
+            minTime: crawlDelayMs,
+        });
+    }
+    return domainLimiters.get(hostname);
+}
+
+async function scheduleCrawl(urlString, task) {
+    await validatePublicUrl(urlString);
+
+    const config = getCrawlConfig();
+    const robotsPolicy = await getRobotsPolicy(urlString, config);
+
+    if (robotsPolicy.failureReason) {
+        const error = new Error(`Crawl blocked: ${robotsPolicy.failureReason}`);
+        error.code = "ROBOTS_CHECK_FAILED";
+        throw error;
+    }
+
+    if (!isUrlAllowedByRobots(urlString, robotsPolicy.parser, config.userAgent)) {
+        const error = new Error(`Crawl blocked by robots.txt: ${urlString}`);
+        error.code = "ROBOTS_DISALLOWED";
+        throw error;
+    }
+
+    const crawlDelayMs = robotsPolicy.crawlDelayMs ?? config.defaultDelayMs;
+    return getDomainLimiter(urlString, config, crawlDelayMs).schedule(task);
+}
+
+async function fetchCrawlText(urlString) {
+    return scheduleCrawl(urlString, async () => {
+        const config = getCrawlConfig();
+        const response = await fetch(urlString, {
+            headers: {
+                "User-Agent": config.userAgent,
+            },
+        });
+
+        if (!response.ok) {
+            throw new Error(`Failed to fetch ${urlString}: HTTP ${response.status}`);
+        }
+
+        return response.text();
+    });
+}
+
 async function scrapeTitle(url) {
-    await validatePublicUrl(url);
-    const data = await (await fetch(url)).text();
+    const data = await fetchCrawlText(url);
     const $ = cheerio.load(data);
     return $("title").text();
 }
 
 async function scrapeWebpage(url = "", rootUrl = "") {
-    await validatePublicUrl(url);
-    const data = await (await fetch(url)).text();
+    const data = await fetchCrawlText(url);
     const $ = cheerio.load(data);
 
     const rootHostname = new URL(rootUrl).hostname;
@@ -212,4 +405,20 @@ function extractHrefsFromScripts($, rootUrl, rootHostname) {
     return hrefs;
 }
 
-export { normalizeUrl, isValidDocUrl, scrapeWebpage, scrapeTitle, generateVectorEmbeddings };
+function resetCrawlStateForTests() {
+    robotsCache.clear();
+    domainLimiters.clear();
+}
+
+export {
+    normalizeUrl,
+    isValidDocUrl,
+    scrapeWebpage,
+    scrapeTitle,
+    generateVectorEmbeddings,
+    getCrawlConfig,
+    parseRobotsTxt,
+    isUrlAllowedByRobots,
+    scheduleCrawl,
+    resetCrawlStateForTests,
+};


### PR DESCRIPTION
## Summary
- add robots.txt enforcement and robots policy caching to backend scraping
- add a per-domain Bottleneck crawl scheduler with configurable delays and concurrency
- make worker crawl/page concurrency knobs configurable and cover robots/scheduler behavior with tests

## Validation
- npm.cmd run build
- node --check backend\utils\ragUtilities.js
- node --check backend\chatWorker.js
- node --test tests\ragUtilities.robots.test.js

Closes #165