### PR TITLE
feat: Add API Key update endpoint and Settings UI edit flow (#154)

### DIFF
--- a/backend/controllers/apikey.controller.js
+++ b/backend/controllers/apikey.controller.js
@@ -187,4 +187,38 @@ const totalNumberOfApiKeys = asyncHandler(async (req, res) => {
     );
 });
 
-export { addApiKey, listApiKeys, removeApiKey, getApiKey, totalNumberOfApiKeys };
+const updateApiKey = asyncHandler(async (req, res) => {
+    const { id } = req.params;
+    const { name, key } = req.body;
+
+    const existingKey = await prisma.apiKey.findUnique({
+        where: { id, userId: req.user.id },
+    });
+
+    if (!existingKey) {
+        throw new ApiError(404, "API key not found");
+    }
+
+    const updateData = {};
+    if (name) updateData.name = name;
+
+    if (key) {
+        const isValid = await checkApiKeyValidity(existingKey.provider, key);
+        if (!isValid) {
+            throw new ApiError(400, "Invalid API key for the existing provider");
+        }
+        const { cipherText, tag, iv } = encryptApiKey(key);
+        updateData.encryptedKey = cipherText;
+        updateData.iv = iv;
+        updateData.tag = tag;
+    }
+
+    await prisma.apiKey.update({
+        where: { id, userId: req.user.id },
+        data: updateData,
+    });
+
+    res.status(200).json(new ApiResponse(200, {}, "API key updated successfully"));
+});
+
+export { addApiKey, listApiKeys, removeApiKey, getApiKey, totalNumberOfApiKeys, updateApiKey };

--- a/backend/routers/apikey.route.js
+++ b/backend/routers/apikey.route.js
@@ -8,6 +8,7 @@ import {
     removeApiKey,
     getApiKey,
     totalNumberOfApiKeys,
+    updateApiKey,
 } from "../controllers/apikey.controller.js";
 
 const apikeyRouter = Router();
@@ -17,5 +18,5 @@ apikeyRouter.route("/list").get(verifyStrictJWT, listApiKeys);
 apikeyRouter.route("/count").get(verifyStrictJWT, totalNumberOfApiKeys);
 apikeyRouter.route("/:id").delete(verifyStrictJWT, validate(apiKeyIdParamSchema), removeApiKey);
 apikeyRouter.route("/:id").get(verifyStrictJWT, validate(apiKeyIdParamSchema), getApiKey);
-
+apikeyRouter.route("/:id").patch(verifyStrictJWT, updateApiKey);
 export default apikeyRouter;

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -191,6 +191,15 @@ export const deleteApiKey = async (id: string) => {
     return result;
 };
 
+export const updateApiKey = async (id: string, payload: { key?: string; name?: string }) => {
+    const result = await apiRequest(`/apikey/${id}`, {
+        method: "PATCH",
+        body: JSON.stringify(payload),
+    });
+    invalidateApiKeyCaches();
+    return result;
+};
+
 export const getApiKeyCount = () => apiRequest<{ count: number }>("/apikey/count", { method: "GET" });
 
 export const getChats = () =>

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -1,8 +1,9 @@
 import { useEffect, useState } from "react";
 import { Sidebar } from "../components/Sidebar";
-import { Key, Trash2, AlertCircle, Eye, EyeOff, Plus, Network } from "lucide-react";
+import { Key, Trash2, AlertCircle, Eye, EyeOff, Plus, Network, Edit2 } from "lucide-react";
 import {
     createApiKey,
+    updateApiKey,
     deleteApiKey,
     getApiKeyCount,
     getApiKeys,
@@ -55,6 +56,7 @@ const Settings = () => {
     const [selectedProvider, setSelectedProvider] = useState<Provider | "">("");
     const [showKey, setShowKey] = useState(false);
     const [isSaving, setIsSaving] = useState(false);
+    const [editingKeyId, setEditingKeyId] = useState<string | null>(null);
 
     const loadApiKeys = async () => {
         setIsLoading(true);
@@ -96,20 +98,28 @@ const Settings = () => {
     };
 
     const handleSaveKey = async () => {
-        if (!newKeyName || !newKeyValue || !selectedProvider) return;
+        if (!newKeyName || (!newKeyValue && !editingKeyId) || !selectedProvider) return;
 
         setIsSaving(true);
         setError("");
         try {
-            await createApiKey({
-                key: newKeyValue,
-                name: newKeyName,
-                provider: selectedProvider,
-            });
+            if (editingKeyId) {
+                await updateApiKey(editingKeyId, {
+                    name: newKeyName,
+                    ...(newKeyValue ? { key: newKeyValue } : {})
+                });
+            } else {
+                await createApiKey({
+                    key: newKeyValue,
+                    name: newKeyName,
+                    provider: selectedProvider,
+                });
+            }
             setNewKeyName("");
             setNewKeyValue("");
             setSelectedProvider("");
             setShowKey(false);
+            setEditingKeyId(null);
             await loadApiKeys();
         } catch (err) {
             setError(err instanceof Error ? err.message : "Failed to save API key.");
@@ -179,7 +189,9 @@ const Settings = () => {
                                 <div className="w-10 h-10 rounded-lg bg-accent-blue/10 flex items-center justify-center border border-accent-blue/20 text-accent-blue">
                                     <Network className="w-5 h-5" />
                                 </div>
-                                <h3 className="text-lg font-medium text-gray-200">Add New Key</h3>
+                                <h3 className="text-lg font-medium text-gray-200">
+                                    {editingKeyId ? "Edit Key" : "Add New Key"}
+                                </h3>
                             </div>
 
                             <div className="grid grid-cols-1 md:grid-cols-2 gap-5 relative z-10">
@@ -203,7 +215,7 @@ const Settings = () => {
                                             type={showKey ? "text" : "password"}
                                             value={newKeyValue}
                                             onChange={(e) => handleKeyChange(e.target.value)}
-                                            placeholder="sk-... (Auto-detects provider)"
+                                            placeholder={editingKeyId ? "(Leave blank to keep existing key)" : "sk-... (Auto-detects provider)"}
                                             className="w-full bg-[#111] border border-white/10 rounded-lg pl-4 pr-12 py-2.5 text-white focus:outline-none focus:border-accent-blue/50 font-mono text-sm"
                                         />
                                         <button
@@ -224,7 +236,8 @@ const Settings = () => {
                                     <select
                                         value={selectedProvider}
                                         onChange={(e) => handleProviderChange(e.target.value)}
-                                        className="w-full bg-[#111] border border-white/10 rounded-lg px-4 py-2.5 text-sm text-white focus:outline-none focus:border-accent-blue/50 appearance-none"
+                                        disabled={!!editingKeyId}
+                                        className="w-full bg-[#111] border border-white/10 rounded-lg px-4 py-2.5 text-sm text-white focus:outline-none focus:border-accent-blue/50 appearance-none disabled:opacity-50"
                                     >
                                         <option value="">Select a provider...</option>
                                         {PROVIDERS.map((p) => (
@@ -236,16 +249,26 @@ const Settings = () => {
                                 </div>
                             </div>
 
-                            <div className="pt-4 border-t border-white/5 mt-4 relative z-10 flex justify-end">
+                            <div className="pt-4 border-t border-white/5 mt-4 relative z-10 flex flex-col-reverse sm:flex-row justify-end gap-3">
+                                {editingKeyId && (
+                                    <button
+                                        onClick={() => {
+                                            setEditingKeyId(null);
+                                            setNewKeyName("");
+                                            setNewKeyValue("");
+                                            setSelectedProvider("");
+                                        }}
+                                        className="bg-white/10 hover:bg-white/20 text-white px-6 py-2.5 rounded-lg text-sm font-medium transition-colors w-full sm:w-auto"
+                                    >
+                                        Cancel Edit
+                                    </button>
+                                )}
                                 <button
                                     onClick={handleSaveKey}
-                                    disabled={
-                                        isSaving || !newKeyName || !newKeyValue || !selectedProvider
-                                    }
+                                    disabled={isSaving || !newKeyName || (!newKeyValue && !editingKeyId) || !selectedProvider}
                                     className="bg-accent-blue hover:bg-blue-600 disabled:opacity-50 disabled:bg-gray-700 disabled:cursor-not-allowed text-white px-6 py-2.5 rounded-lg text-sm font-medium transition-colors flex items-center gap-2 justify-center shrink-0 w-full sm:w-auto"
                                 >
-                                    <Plus className="w-4 h-4" />
-                                    {isSaving ? "Saving..." : "Save Key Configuration"}
+                                    {isSaving ? "Saving..." : (editingKeyId ? "Update Key" : <><Plus className="w-4 h-4" /> Save Key Configuration</>)}
                                 </button>
                             </div>
                         </div>
@@ -299,13 +322,28 @@ const Settings = () => {
                                             </div>
                                         </div>
 
-                                        <button
-                                            onClick={() => handleDeleteKey(key.id)}
-                                            className="p-2 bg-red-500/10 text-red-400 rounded-lg hover:bg-red-500/20 transition-colors self-end sm:self-auto shrink-0"
-                                            title="Delete Key"
-                                        >
-                                            <Trash2 className="w-4 h-4" />
-                                        </button>
+                                        <div className="flex gap-2 self-end sm:self-auto shrink-0">
+                                            <button
+                                                onClick={() => {
+                                                    setEditingKeyId(key.id);
+                                                    setNewKeyName(key.name);
+                                                    setNewKeyValue("");
+                                                    setSelectedProvider(key.provider as Provider);
+                                                    window.scrollTo({ top: 0, behavior: "smooth" });
+                                                }}
+                                                className="p-2 bg-accent-blue/10 text-accent-blue rounded-lg hover:bg-accent-blue/20 transition-colors"
+                                                title="Edit Key"
+                                            >
+                                                <Edit2 className="w-4 h-4" />
+                                            </button>
+                                            <button
+                                                onClick={() => handleDeleteKey(key.id)}
+                                                className="p-2 bg-red-500/10 text-red-400 rounded-lg hover:bg-red-500/20 transition-colors"
+                                                title="Delete Key"
+                                            >
+                                                <Trash2 className="w-4 h-4" />
+                                            </button>
+                                        </div>
                                     </div>
                                 ))
                             ) : (


### PR DESCRIPTION
## Resolves #154

### Description
This PR introduces the ability to edit an existing API key record without needing to delete and recreate it. It adds a new `PATCH` endpoint to re-validate and re-encrypt the keys, and introduces a seamless edit flow directly into the Settings UI.

### Changes Made
- **Backend**:
  - `backend/controllers/apikey.controller.js`: Added the `updateApiKey` controller function to handle the `PATCH` request. The function intelligently checks if a new key value is provided; if so, it re-validates the key against the existing provider and re-encrypts it before saving.
  - `backend/routers/apikey.route.js`: Registered the `PATCH /api/v1/apikey/:id` route.
- **Frontend**:
  - `src/lib/api.ts`: Added the `updateApiKey` client function and ensured it busts the API keys cache upon a successful update.
  - `src/pages/Settings.tsx`: 
    - Introduced an `editingKeyId` state to toggle between "Create" and "Edit" modes.
    - Added an **Edit** button (pencil icon) next to the Delete button for each key in the list.
    - Updated the form header, password placeholder, and provider dropdown (disabled during edit) to dynamically adapt to the edit state.
    - Provided an inline "Cancel Edit" button and updated the save button to reflect "Update Key" when in edit mode.

### Acceptance Criteria met
- [x] `PATCH /api/v1/apikey/:id` accepts name and/or key updates.
- [x] Updated keys are revalidated and re-encrypted before saving.
- [x] The Settings page provides an edit flow for existing keys.
- [x] Reuses existing encrypt/decrypt utilities.
- [x] Invalidates the model/key caches after a successful update.