### PR TITLE
fix: Synchronize cancel processing Redis key (#143)

### DIFF
--- a/backend/chatWorker.js
+++ b/backend/chatWorker.js
@@ -1,6 +1,6 @@
 import "dotenv/config";
 import { Worker } from "bullmq";
-import redis from "./utils/redis.js";
+import redis, { getChatProgressKey } from "./utils/redis.js";
 import {
     normalizeUrl,
     isValidDocUrl,
@@ -56,7 +56,7 @@ async function processVector(docsRootUrl, chatId, collectionName, chatSourceId) 
         console.log("Total unique links found:", totalLinks);
 
         await redis.setex(
-            chatId,
+            getChatProgressKey(chatId),
             3600,
             JSON.stringify({
                 status: "PROCESSING",
@@ -139,7 +139,7 @@ async function processVector(docsRootUrl, chatId, collectionName, chatSourceId) 
                     }
 
                     await redis.setex(
-                        chatId,
+                        getChatProgressKey(chatId),
                         3600,
                         JSON.stringify({
                             status: "PROCESSING",
@@ -151,12 +151,12 @@ async function processVector(docsRootUrl, chatId, collectionName, chatSourceId) 
                 }
             } catch (err) {
                 console.error(`Failed link ${link}:`, err.message);
-                await redis.setex(chatId, 3600, JSON.stringify({ status: "FAILED" }));
+                await redis.setex(getChatProgressKey(chatId), 3600, JSON.stringify({ status: "FAILED" }));
                 continue;
             }
         }
     } catch (err) {
-        await redis.setex(chatId, 3600, JSON.stringify({ status: "FAILED" }));
+        await redis.setex(getChatProgressKey(chatId), 3600, JSON.stringify({ status: "FAILED" }));
         throw err;
     }
 }
@@ -164,7 +164,7 @@ async function processVector(docsRootUrl, chatId, collectionName, chatSourceId) 
 async function processVectorLess(docsRootUrl, chatId, chatSourceId) {
     try {
         const { maxPagesPerJob, vectorlessBatchSize } = getWorkerConfig();
-        await redis.setex(chatId, 3600, JSON.stringify({ status: "PROCESSING", progress: 0 }));
+        await redis.setex(getChatProgressKey(chatId), 3600, JSON.stringify({ status: "PROCESSING", progress: 0 }));
 
         const rootUrl = normalizeUrl(docsRootUrl);
         console.log("Scraping root:", rootUrl);
@@ -198,7 +198,7 @@ async function processVectorLess(docsRootUrl, chatId, chatSourceId) {
             i += vectorlessBatchSize;
 
             await redis.setex(
-                chatId,
+                getChatProgressKey(chatId),
                 3600,
                 JSON.stringify({
                     status: "PROCESSING",
@@ -225,7 +225,7 @@ async function processVectorLess(docsRootUrl, chatId, chatSourceId) {
             },
         });
 
-        await redis.setex(chatId, 3600, JSON.stringify({ status: "READY", progress: 100 }));
+        await redis.setex(getChatProgressKey(chatId), 3600, JSON.stringify({ status: "READY", progress: 100 }));
 
         await prisma.chat.update({
             where: { id: chatId },
@@ -244,7 +244,7 @@ async function processVectorLess(docsRootUrl, chatId, chatSourceId) {
         return;
     } catch (error) {
         console.error("Error VectorLess:", error);
-        await redis.setex(chatId, 3600, JSON.stringify({ status: "FAILED" }));
+        await redis.setex(getChatProgressKey(chatId), 3600, JSON.stringify({ status: "FAILED" }));
         throw error;
     }
 }

--- a/backend/controllers/chat.controller.js
+++ b/backend/controllers/chat.controller.js
@@ -5,7 +5,7 @@ import { ApiError } from "../utils/ApiError.js";
 import { scrapeWebpage } from "../utils/ragUtilities.js";
 import { cleanupQdrantCollections } from "../utils/qdrantCleanup.js";
 import { Queue } from "bullmq";
-import redis from "../utils/redis.js";
+import redis, { getChatProgressKey } from "../utils/redis.js";
 import crypto from "crypto";
 
 const chatCreationQueue = new Queue("chatCreation");
@@ -233,7 +233,7 @@ const progressStatus = asyncHandler(async (req, res) => {
         },
     });
 
-    const redisData = await redis.get(chat.id);
+    const redisData = await redis.get(getChatProgressKey(chat.id));
     const progress = normalizeProgress(redisData ? JSON.parse(redisData) : DEFAULT_PROGRESS);
 
     res.status(200).json(
@@ -462,21 +462,20 @@ const cancelProcessing = asyncHandler(async (req, res) => {
 
     if (job) {
         await job.remove();
-        await redis.setex(chat.collectionName, 3600, JSON.stringify({ status: "READY", progress: 100 }));
-
-        await prisma.chat
-            .update({
-                where: { id: chatId },
-                data: { status: "READY" },
-            })
-            .catch((err) => {
-                throw new ApiError(500, `Failed Update: ${err.message}`, err);
-            });
-
-        res.status(200).json(new ApiResponse(200, null, "Chat processing cancelled successfully"));
-    } else {
-        throw new ApiError(404, "Job not found or already completed");
     }
+
+    await redis.setex(getChatProgressKey(chatId), 3600, JSON.stringify({ status: "READY", progress: 100 }));
+
+    await prisma.chat
+        .update({
+            where: { id: chatId },
+            data: { status: "READY" },
+        })
+        .catch((err) => {
+            throw new ApiError(500, `Failed Update: ${err.message}`, err);
+        });
+
+    res.status(200).json(new ApiResponse(200, null, "Chat processing cancelled successfully"));
 });
 
 const deleteChat = asyncHandler(async (req, res) => {

--- a/backend/utils/redis.js
+++ b/backend/utils/redis.js
@@ -10,4 +10,6 @@ redis.on("error", (err) => {
     console.error("Redis error:", err);
 });
 
+export const getChatProgressKey = (chatId) => `chat-progress:${chatId}`;
+
 export default redis;

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -232,6 +232,13 @@ export const getChatStatus = (chatId: string) =>
 export const getChatDetails = (chatId: string) =>
     apiRequest<{ chat: ChatItem }>(`/chat/${chatId}`, { method: "GET" });
 
+export const cancelChat = async (chatId: string) => {
+    const result = await apiRequest(`/chat/${chatId}/cancel`, {
+        method: "POST",
+    });
+    return result;
+};
+
 export const getPagesIndexed = (chatId: string) =>
     withCache(cacheKey(`/chat/pages-indexed/${chatId}`), 5 * 60 * 1000, () =>
         apiRequest<{

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -23,6 +23,7 @@ import {
     getLifetimeTokens,
     getRecentChats,
     invalidatePagesIndexed,
+    cancelChat,
     type ChatItem,
 } from "../lib/api";
 import { formatTokens } from "../lib/format";
@@ -91,6 +92,7 @@ const Dashboard = () => {
     const [error, setError] = useState("");
     const [isCreating, setIsCreating] = useState(false);
     const [isDeleting, setIsDeleting] = useState(false);
+    const [isCancelling, setIsCancelling] = useState(false);
     const [lifetimeTokens, setLifetimeTokens] = useState(0);
     const [chatProgress, setChatProgress] = useState<
         Record<string, { status: string; progress: number }>
@@ -293,6 +295,19 @@ const Dashboard = () => {
             setError(err instanceof Error ? err.message : "Failed to delete chat.");
         } finally {
             setIsDeleting(false);
+        }
+    };
+
+    const handleCancelChat = async (chatId: string) => {
+        setIsCancelling(true);
+        try {
+            await cancelChat(chatId);
+            showToast("Cancellation requested. Updating state...");
+            await pollStatuses(); // Force an immediate poll to reflect READY
+        } catch (err) {
+            setError(err instanceof Error ? err.message : "Failed to cancel chat.");
+        } finally {
+            setIsCancelling(false);
         }
     };
 
@@ -589,10 +604,12 @@ const Dashboard = () => {
                                                 )}
                                                 {liveStatus === "processing" && (
                                                     <button
-                                                        disabled
-                                                        className="flex-1 flex items-center justify-center gap-2 py-2 rounded-lg text-sm font-medium transition-colors bg-white/10 text-white/40 cursor-not-allowed opacity-50"
+                                                        onClick={() => handleCancelChat(chat.id)}
+                                                        disabled={isCancelling}
+                                                        className="flex-1 flex items-center justify-center gap-2 py-2 rounded-lg text-sm font-medium transition-colors bg-red-500/10 hover:bg-red-500/20 text-red-400 border border-red-500/10"
                                                     >
-                                                        Open Chat
+                                                        <X className="w-3.5 h-3.5" />
+                                                        {isCancelling ? "Cancelling..." : "Cancel"}
                                                     </button>
                                                 )}
                                                 {liveStatus === "failed" && (


### PR DESCRIPTION
## Resolves #143

### Description
This PR resolves an inconsistency where the dashboard showed stale job status data after a chat cancellation. The `progressStatus` endpoint read progress data using `chat.id`, but the `cancelProcessing` endpoint previously updated the Redis progress using `chat.collectionName`. This PR aligns both of those endpoints and the background worker to use a standardized Redis progress key format.

### Changes Made
- **Backend**:
  - `backend/utils/redis.js`: Introduced a new `getChatProgressKey` helper function to standardise Redis progress keys.
  - `backend/chatWorker.js`: Updated all `redis.setex` instances (for both vector and vectorless scraping) to write live progress using the `getChatProgressKey(chatId)` helper.
  - `backend/controllers/chat.controller.js`: Updated the `progressStatus` and `cancelProcessing` endpoints to use the standard helper. Furthermore, `cancelProcessing` was refactored to be idempotent—even if the BullMQ job is no longer active, it guarantees the Redis key and Postgres DB are set to `READY`.
- **Frontend**:
  - `src/lib/api.ts`: Added the `cancelChat` API endpoint wrapper.
  - `src/pages/Dashboard.tsx`: Added an active `Cancel` button (with an `X` icon) that replaces the disabled "Open Chat" button for jobs in the `PROCESSING` state. The dashboard automatically forces a status poll once the cancel request completes to clear the "processing" progress bar instantly.

### Acceptance Criteria met
- [x] Cancelling a chat updates the same Redis key used by `GET /chat/status/:chatId`.
- [x] The dashboard stops polling the cancelled chat promptly.
- [x] The UI and backend agree on the final state after cancel.
- [x] Extracted a single helper for the progress key, reused in the worker, status endpoint, and cancel endpoint.
- [x] Cancellation remains idempotent so repeated clicks do not break the state.