### PR TITLE
fix: abort active chat stream on cleanup

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -264,6 +264,7 @@ export const sendMessageStream = async (payload: {
     provider: string;
     chatId: string;
     onChunk?: (chunk: string) => void;
+    signal?: AbortSignal; 
 }) => {
     const token = getAccessToken();
     const headers = new Headers({ "Content-Type": "application/json" });
@@ -276,6 +277,7 @@ export const sendMessageStream = async (payload: {
         headers,
         credentials: "include",
         body: JSON.stringify(payload),
+        signal: payload.signal, 
     });
 
     if (!response.ok || !response.body) {

--- a/src/pages/ChatPage.tsx
+++ b/src/pages/ChatPage.tsx
@@ -305,9 +305,13 @@ export const ChatPage = () => {
     const pendingChunkRef = useRef("");
     const chunkRafRef = useRef<number | null>(null);
     const firstChunkReceivedRef = useRef(false);
+    const abortControllerRef = useRef<AbortController | null>(null);
 
     useEffect(() => {
         return () => {
+            abortControllerRef.current?.abort();
+            abortControllerRef.current = null;
+
             if (chunkRafRef.current !== null) {
                 window.cancelAnimationFrame(chunkRafRef.current);
                 chunkRafRef.current = null;
@@ -414,6 +418,7 @@ export const ChatPage = () => {
         ]);
 
         try {
+            abortControllerRef.current = new AbortController();
             const flushPendingChunks = () => {
                 const buffered = pendingChunkRef.current;
                 if (!buffered) return;
@@ -439,6 +444,7 @@ export const ChatPage = () => {
                 model: selectedOption.model,
                 provider: selectedOption.provider,
                 chatId,
+                signal: abortControllerRef.current.signal, 
                 onChunk: (chunk) => {
                     if (!firstChunkReceivedRef.current) {
                         firstChunkReceivedRef.current = true;


### PR DESCRIPTION
Closes #152 

summary:
* Added AbortController support for chat streaming requests.
* Stop active chat streams when ChatPage is cleaned up or unmounted.
* Clear active request references after aborting.
* Keep the existing logout behavior that clears cached session state.

This helps make sure streaming responses don't keep running after a user logs out or navigates away, and reduces the chance of stale session data hanging around in memory.