### PR TITLE
feat: add copy buttons to code blocks with Copied! feedback

### DIFF
--- a/src/components/CodeBlock.tsx
+++ b/src/components/CodeBlock.tsx
@@ -1,0 +1,91 @@
+import { useState, useRef, useEffect, useMemo } from "react";
+import hljs from "highlight.js";
+import "highlight.js/styles/atom-one-dark.css";
+import { Code, Check } from "lucide-react";
+
+const escapeHtml = (text: string) =>
+    text.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+
+type CopyStatus = "idle" | "copied" | "failed";
+
+const CodeBlock = ({ language, code }: { language?: string; code: string }) => {
+    const [status, setStatus] = useState<CopyStatus>("idle");
+    const timeoutRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+
+    const resetStatus = () => setStatus("idle");
+
+    useEffect(() => {
+        return () => {
+            if (timeoutRef.current) clearTimeout(timeoutRef.current);
+        };
+    }, []);
+
+    const scheduleReset = () => {
+        if (timeoutRef.current) clearTimeout(timeoutRef.current);
+        timeoutRef.current = setTimeout(resetStatus, 2000);
+    };
+
+    const handleCopy = async () => {
+        try {
+            await navigator.clipboard.writeText(code);
+            setStatus("copied");
+            scheduleReset();
+        } catch {
+            console.error("Failed to copy code to clipboard");
+            setStatus("failed");
+            scheduleReset();
+        }
+    };
+
+    const highlighted = useMemo(() => {
+        try {
+            if (language && hljs.getLanguage(language)) {
+                return hljs.highlight(code, { language }).value;
+            }
+            return hljs.highlightAuto(code).value;
+        } catch {
+            return escapeHtml(code);
+        }
+    }, [language, code]);
+
+    const isCopied = status === "copied";
+    const isFailed = status === "failed";
+    const btnLabel = isCopied ? "Copied" : isFailed ? "Copy failed" : "Copy code to clipboard";
+
+    return (
+        <div className="my-4 rounded-xl overflow-hidden bg-[#0a0a0e] border border-white/10 shadow-xl">
+            <div className="flex items-center justify-between px-4 py-2 bg-white/5 border-b border-white/5">
+                <div className="flex items-center gap-2 text-sm font-medium text-gray-400">
+                    <Code className="w-3.5 h-3.5" />
+                    {language || "code"}
+                </div>
+                <button
+                    type="button"
+                    onClick={handleCopy}
+                    aria-label={btnLabel}
+                    className="flex items-center gap-1.5 text-sm uppercase font-bold tracking-wider transition-colors cursor-pointer"
+                >
+                    {isCopied ? (
+                        <>
+                            <Check className="w-3.5 h-3.5 text-green-400" />
+                            <span className="text-green-400">Copied!</span>
+                        </>
+                    ) : isFailed ? (
+                        <span className="text-red-400">Failed!</span>
+                    ) : (
+                        <span className="text-gray-500 hover:text-white">Copy</span>
+                    )}
+                </button>
+            </div>
+            <div className="p-4 overflow-x-auto text-sm font-mono leading-relaxed text-gray-300 custom-scrollbar w-full max-w-full">
+                <pre>
+                    <code
+                        dangerouslySetInnerHTML={{ __html: highlighted }}
+                    />
+                </pre>
+            </div>
+        </div>
+    );
+};
+
+export default CodeBlock;

--- a/src/pages/ChatPage.tsx
+++ b/src/pages/ChatPage.tsx
@@ -36,7 +36,6 @@ import {
     Search,
     ArrowLeft,
     Check,
-    Code,
     X,
     Loader2,
     Database,
@@ -45,10 +44,9 @@ import {
     Share2,
 } from "lucide-react";
 import clsx from "clsx";
-import hljs from "highlight.js";
-import "highlight.js/styles/atom-one-dark.css";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
+import CodeBlock from "../components/CodeBlock";
 import {
     getApiKeys,
     getChatDetails,
@@ -1383,19 +1381,6 @@ export const ChatPage = () => {
     );
 };
 
-// Helper Components
-
-const highlightCode = (language: string, code: string) => {
-    try {
-        if (language && hljs.getLanguage(language)) {
-            return hljs.highlight(code, { language }).value;
-        }
-        return hljs.highlightAuto(code).value;
-    } catch {
-        return code.replace(/</g, "&lt;").replace(/>/g, "&gt;");
-    }
-};
-
 const ChatMessage = ({
     message,
     onViewSources,
@@ -1514,33 +1499,7 @@ const ChatMessage = ({
                                             );
                                         }
 
-                                        return (
-                                            <div className="my-4 rounded-xl overflow-hidden bg-[#0a0a0e] border border-white/10 shadow-xl">
-                                                <div className="flex items-center justify-between px-4 py-2 bg-white/5 border-b border-white/5">
-                                                    <div className="flex items-center gap-2 text-sm font-medium text-gray-400">
-                                                        <Code className="w-3.5 h-3.5" />
-                                                        {language || "code"}
-                                                    </div>
-                                                    <button
-                                                        onClick={() =>
-                                                            navigator.clipboard.writeText(code)
-                                                        }
-                                                        className="text-sm uppercase font-bold tracking-wider text-gray-500 hover:text-white transition-colors cursor-pointer"
-                                                    >
-                                                        Copy
-                                                    </button>
-                                                </div>
-                                                <div className="p-4 overflow-x-auto text-sm font-mono leading-relaxed text-gray-300 custom-scrollbar w-full max-w-full">
-                                                    <pre>
-                                                        <code
-                                                            dangerouslySetInnerHTML={{
-                                                                __html: highlightCode(language, code),
-                                                            }}
-                                                        />
-                                                    </pre>
-                                                </div>
-                                            </div>
-                                        );
+                                        return <CodeBlock language={language} code={code} />;
                                     },
                                 }}
                             >

--- a/src/pages/SharedChatPage.tsx
+++ b/src/pages/SharedChatPage.tsx
@@ -33,16 +33,14 @@ import {
     Search,
     ArrowLeft,
     Check,
-    Code,
     X,
     Loader2,
     Database,
 } from "lucide-react";
 import clsx from "clsx";
-import hljs from "highlight.js";
-import "highlight.js/styles/atom-one-dark.css";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
+import CodeBlock from "../components/CodeBlock";
 import {
     getSharedChatDetails,
     getSharedChatMessages,
@@ -567,19 +565,6 @@ export const SharedChatPage = () => {
     );
 };
 
-// Helper Components
-
-const highlightCode = (language: string, code: string) => {
-    try {
-        if (language && hljs.getLanguage(language)) {
-            return hljs.highlight(code, { language }).value;
-        }
-        return hljs.highlightAuto(code).value;
-    } catch {
-        return code.replace(/</g, "&lt;").replace(/>/g, "&gt;");
-    }
-};
-
 const ChatMessage = ({
     message,
     onViewSources,
@@ -698,33 +683,7 @@ const ChatMessage = ({
                                             );
                                         }
 
-                                        return (
-                                            <div className="my-4 rounded-xl overflow-hidden bg-[#0a0a0e] border border-white/10 shadow-xl">
-                                                <div className="flex items-center justify-between px-4 py-2 bg-white/5 border-b border-white/5">
-                                                    <div className="flex items-center gap-2 text-sm font-medium text-gray-400">
-                                                        <Code className="w-3.5 h-3.5" />
-                                                        {language || "code"}
-                                                    </div>
-                                                    <button
-                                                        onClick={() =>
-                                                            navigator.clipboard.writeText(code)
-                                                        }
-                                                        className="text-sm uppercase font-bold tracking-wider text-gray-500 hover:text-white transition-colors cursor-pointer"
-                                                    >
-                                                        Copy
-                                                    </button>
-                                                </div>
-                                                <div className="p-4 overflow-x-auto text-sm font-mono leading-relaxed text-gray-300 custom-scrollbar w-full max-w-full">
-                                                    <pre>
-                                                        <code
-                                                            dangerouslySetInnerHTML={{
-                                                                __html: highlightCode(language, code),
-                                                            }}
-                                                        />
-                                                    </pre>
-                                                </div>
-                                            </div>
-                                        );
+                                        return <CodeBlock language={language} code={code} />;
                                     },
                                 }}
                             >


### PR DESCRIPTION
Closes #155
### Summary
Extracted code block rendering into a reusable `CodeBlock` component with "Copied!" feedback, improving the copy experience for code snippets in chat responses.
### Changes
- **New `src/components/CodeBlock.tsx`** — reusable component with:
  - Copy button that shows "Copied!" + checkmark for 2 seconds after click
  - `aria-label` for accessibility ("Copy code to clipboard" / "Copied")
  - Syntax highlighting via highlight.js (same as before)
- **Updated `src/pages/ChatPage.tsx`** and **`src/pages/SharedChatPage.tsx`** — replaced duplicate inline code block rendering with the shared `CodeBlock` component, reducing ~80 lines of duplication
- Removed unused `Code` icon import and `highlightCode` helper from both page files
### Files
- `src/components/CodeBlock.tsx` — new
- `src/pages/ChatPage.tsx` — refactored
- `src/pages/SharedChatPage.tsx` — refactored