### PR TITLE
Add loading state for API key deletion

### DIFF
--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -55,6 +55,7 @@ const Settings = () => {
     const [selectedProvider, setSelectedProvider] = useState<Provider | "">("");
     const [showKey, setShowKey] = useState(false);
     const [isSaving, setIsSaving] = useState(false);
+    const [deletingKeyId, setDeletingKeyId] = useState<string | null>(null);
 
     const loadApiKeys = async () => {
         setIsLoading(true);
@@ -120,11 +121,14 @@ const Settings = () => {
 
     const handleDeleteKey = async (id: string) => {
         setError("");
+        setDeletingKeyId(id);
         try {
             await deleteApiKey(id);
             await loadApiKeys();
         } catch (err) {
             setError(err instanceof Error ? err.message : "Failed to delete API key.");
+        } finally {
+            setDeletingKeyId(null);
         }
     };
 
@@ -301,10 +305,15 @@ const Settings = () => {
 
                                         <button
                                             onClick={() => handleDeleteKey(key.id)}
-                                            className="p-2 bg-red-500/10 text-red-400 rounded-lg hover:bg-red-500/20 transition-colors self-end sm:self-auto shrink-0"
+                                            disabled={deletingKeyId !== null}
+                                            className="p-2 bg-red-500/10 text-red-400 rounded-lg hover:bg-red-500/20 transition-colors self-end sm:self-auto shrink-0 disabled:opacity-50 disabled:cursor-not-allowed"
                                             title="Delete Key"
                                         >
-                                            <Trash2 className="w-4 h-4" />
+                                            {deletingKeyId === key.id ? (
+                                                <span className="text-xs">Deleting...</span>
+                                            ) : (
+                                                <Trash2 className="w-4 h-4" />
+                                            )}
                                         </button>
                                     </div>
                                 ))


### PR DESCRIPTION
## Summary
Adds a loading state when deleting API keys on the Settings page.

## Changes
- Added `deletingKeyId` state to track the active deletion request.
- Disabled delete actions while a deletion is in progress.
- Shows "Deleting..." on the API key currently being deleted.
- Resets loading state in a `finally` block after the request completes.

## Acceptance Criteria
- [x] Delete button shows a loading state.
- [x] Delete button is disabled while deletion is in progress.
- [x] Duplicate delete actions are prevented.
- [x] Loading state is cleared after completion.