### PR TITLE
fix: persist ingestion failure details in database

### DIFF
--- a/backend/chatWorker.js
+++ b/backend/chatWorker.js
@@ -23,6 +23,35 @@ function sanitizeErrorMessage(message) {
     return safe.length > 200 ? `${safe.slice(0, 197)}...` : safe;
 }
 
+async function markChatFailed(chatId, error) {
+    const failureReason = sanitizeErrorMessage(error?.message) || "Ingestion failed";
+
+    await redis.setex(
+        getChatProgressKey(chatId),
+        3600,
+        JSON.stringify({
+            status: "FAILED",
+            progress: 0,
+            failureReason,
+        }),
+    );
+
+    await prisma.chat
+        .update({
+            where: { id: chatId },
+            data: {
+                status: "FAILED",
+                failedAt: new Date(),
+                failureReason,
+            },
+        })
+        .catch((dbError) => {
+            console.error("Failed to persist chat failure state:", dbError.message);
+        });
+
+    return failureReason;
+}
+
 function getErrorCode(err) {
     if (!err) return "UNKNOWN_ERROR";
     if (typeof err.code === "string" && err.code.trim()) return err.code.trim().slice(0, 64);
@@ -151,12 +180,12 @@ async function processVector(docsRootUrl, chatId, collectionName, chatSourceId) 
                 }
             } catch (err) {
                 console.error(`Failed link ${link}:`, err.message);
-                await redis.setex(getChatProgressKey(chatId), 3600, JSON.stringify({ status: "FAILED" }));
+                await markChatFailed(chatId, err);
                 continue;
             }
         }
     } catch (err) {
-        await redis.setex(getChatProgressKey(chatId), 3600, JSON.stringify({ status: "FAILED" }));
+        await markChatFailed(chatId, err);
         throw err;
     }
 }
@@ -244,7 +273,7 @@ async function processVectorLess(docsRootUrl, chatId, chatSourceId) {
         return;
     } catch (error) {
         console.error("Error VectorLess:", error);
-        await redis.setex(getChatProgressKey(chatId), 3600, JSON.stringify({ status: "FAILED" }));
+        await markChatFailed(chatId, error);
         throw error;
     }
 }
@@ -278,6 +307,7 @@ const worker = new Worker(
                 },
             });
         } catch (err) {
+            await markChatFailed(chatId, err);
             await prisma.ingestionRun.update({
                 where: { id: run.id },
                 data: {

--- a/backend/controllers/chat.controller.js
+++ b/backend/controllers/chat.controller.js
@@ -189,6 +189,16 @@ const DEFAULT_PROGRESS = {
     progress: 0,
 };
 
+const sanitizeFailureReason = (value) => {
+    if (!value) return null;
+    const safe = String(value)
+        .replace(/[\r\n\t]+/g, " ")
+        .replace(/\s+/g, " ")
+        .trim();
+    if (!safe) return null;
+    return safe.length > 200 ? `${safe.slice(0, 197)}...` : safe;
+};
+
 const normalizeProgress = (progress = {}) => {
     const data = progress && typeof progress === "object" ? progress : {};
 
@@ -211,6 +221,9 @@ const progressStatus = asyncHandler(async (req, res) => {
         },
         select: {
             id: true,
+            status: true,
+            failedAt: true,
+            failureReason: true,
         },
     });
 
@@ -234,11 +247,31 @@ const progressStatus = asyncHandler(async (req, res) => {
     });
 
     const redisData = await redis.get(getChatProgressKey(chat.id));
-    const progress = normalizeProgress(redisData ? JSON.parse(redisData) : DEFAULT_PROGRESS);
-
-    res.status(200).json(
-        new ApiResponse(200, { progress, latestIngestionRun }, "Progress fetched successfully"),
+    const redisProgress = redisData ? JSON.parse(redisData) : null;
+    const failureReason =
+        chat.status === "FAILED"
+            ? sanitizeFailureReason(chat.failureReason) ||
+              sanitizeFailureReason(latestIngestionRun?.errorMessage) ||
+              sanitizeFailureReason(redisProgress?.failureReason)
+            : null;
+    const progress = normalizeProgress(
+        redisProgress || {
+            status: chat.status,
+            progress: chat.status === "READY" ? 100 : 0,
+            failureReason,
+        },
     );
+
+    const response = {
+        progress,
+        latestIngestionRun,
+    };
+
+    if (chat.status === "FAILED") {
+        response.failureReason = failureReason;
+    }
+
+    res.status(200).json(new ApiResponse(200, response, "Progress fetched successfully"));
 });
 
 const recentFailedIngestionRuns = asyncHandler(async (req, res) => {

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -48,6 +48,8 @@ model Chat {
     userId         String        @map("user_id")
     status         ChatStatus    @default(QUEUED)
     createdAt      DateTime      @default(now()) @map("created_at")
+    failedAt       DateTime?     @map("failed_at")
+    failureReason  String?       @map("failure_reason")
     collectionName String?       @map("collection_name")
     shareToken     String?       @unique @map("share_token")
     createdBy      User          @relation(fields: [userId], references: [id])


### PR DESCRIPTION
## Summary

Persists ingestion failure details in the database and surfaces them through the chat status API.

Previously, ingestion failures were only available through logs and transient Redis state. This change stores failure information in the database so it survives Redis expiry and process restarts, while providing users with a stable and safe failure message.

## Changes

### Backend

* Added persistent failure fields to `Chat`:

  * `failedAt`
  * `failureReason`

* Updated ingestion worker failure handling:

  * Marks chats as `FAILED`
  * Stores a failure timestamp
  * Persists a sanitized, user-safe failure reason
  * Updates Redis with the same safe failure message

* Updated `GET /api/v1/chat/status/:chatId`:

  * Returns `failureReason` when status is `FAILED`
  * Falls back to database status information when Redis state is unavailable
  * Ensures failure details remain accessible after Redis expiry or service restarts

### Safety

* Failure messages are sanitized before persistence
* No API keys, stack traces, tokens, or sensitive information are exposed to users

## Example Response

```json
{
  "status": "FAILED",
  "failureReason": "No data scraped."
}
```

## Validation

* `node --check backend/chatWorker.js`
* `node --check backend/controllers/chat.controller.js`
* `npx prisma validate`

## Notes

* Prisma schema was updated, but migration files were intentionally omitted per maintainer guidance.
* Failure information now survives process restarts and Redis expiration.

Closes #67
