### PR TITLE
feat: add cost accounting to usage tracking

### DIFF
--- a/backend/controllers/chatMessage.controller.js
+++ b/backend/controllers/chatMessage.controller.js
@@ -3,7 +3,13 @@ import redis from "../utils/redis.js";
 import asyncHandler from "../utils/asyncHandler.js";
 import { ApiResponse } from "../utils/ApiResponse.js";
 import { ApiError } from "../utils/ApiError.js";
-import { LLM_MODELS, PROVIDERS_BASE_URLS, MEM0_ENABLED, DAILY_TOKEN_BUDGET } from "../utils/constants.js";
+import {
+    LLM_MODELS,
+    PROVIDERS_BASE_URLS,
+    MEM0_ENABLED,
+    DAILY_TOKEN_BUDGET,
+    estimateUsageCostUsd,
+} from "../utils/constants.js";
 import OpenAI from "openai";
 import { qdrant, treeindex } from "../utils/ragClients.js";
 import { decryptApiKey } from "../utils/decrypt.js";
@@ -291,12 +297,21 @@ const sendMessage = asyncHandler(async (req, res) => {
             });
         }
 
+        const usageCost = estimateUsageCostUsd({
+            provider: provider === "DEFAULT" ? "DEFAULT" : apiKey.provider,
+            model,
+            inputTokens,
+            outputTokens,
+        });
+
         let usageEventData = {
             userId: req.user.id,
             messageId: chatMessage.id,
             inputTokens,
             outputTokens,
             chatId: chat.id,
+            estimatedCostUsd: usageCost.estimatedCostUsd,
+            priceVersion: usageCost.priceVersion,
         };
         if (model != "default" && provider != "DEFAULT" && apiKeyId) {
             usageEventData = {

--- a/backend/controllers/usage.controller.js
+++ b/backend/controllers/usage.controller.js
@@ -10,11 +10,24 @@ const totalTokensUsedInLifetime = asyncHandler(async (req, res) => {
         _sum: {
             inputTokens: true,
             outputTokens: true,
+            estimatedCostUsd: true,
         },
     });
     return res
         .status(200)
-        .json(new ApiResponse(200, usage, "Total tokens used in lifetime retrieved successfully"));
+        .json(
+            new ApiResponse(
+                200,
+                {
+                    _sum: {
+                        inputTokens: usage._sum.inputTokens || 0,
+                        outputTokens: usage._sum.outputTokens || 0,
+                        estimatedCostUsd: Number(usage._sum.estimatedCostUsd || 0),
+                    },
+                },
+                "Total tokens used in lifetime retrieved successfully",
+            ),
+        );
 });
 
 const tokensUsedByGroup = asyncHandler(async (req, res) => {
@@ -60,12 +73,15 @@ const tokensUsedByGroup = asyncHandler(async (req, res) => {
         SELECT 
             DATE_TRUNC(${truncUnit}, u."timestamp") AS period,
             m."llm_model" AS "model",
+            a."provider" AS "provider",
             SUM(u."input_tokens") AS "totalInput",
-            SUM(u."output_tokens") AS "totalOutput"
+            SUM(u."output_tokens") AS "totalOutput",
+            SUM(u."estimated_cost_usd")::float8 AS "estimatedCostUsd"
         FROM "UsageEvents" u
         JOIN "ChatMessage" m ON u."message_id" = m."id"
+        LEFT JOIN "ApiKey" a ON u."apikey_id" = a."id"
         WHERE u."user_id" = ${req.user.id}
-        GROUP BY period, "model"
+        GROUP BY period, "model", "provider"
         ORDER BY period DESC, "totalInput" DESC;
     `;
 
@@ -79,8 +95,10 @@ const tokensUsedByGroup = asyncHandler(async (req, res) => {
         }
         acc[periodKey].usageByModels.push({
             model: curr.model,
+            provider: curr.provider,
             totalInput: Number(curr.totalInput || 0),
             totalOutput: Number(curr.totalOutput || 0),
+            estimatedCostUsd: Number(curr.estimatedCostUsd || 0),
         });
         return acc;
     }, {});
@@ -106,6 +124,7 @@ const topChatsByTokensUsed = asyncHandler(async (req, res) => {
         _sum: {
             inputTokens: true,
             outputTokens: true,
+            estimatedCostUsd: true,
         },
         orderBy: {
             _sum: {
@@ -130,7 +149,17 @@ const topChatsByTokensUsed = asyncHandler(async (req, res) => {
     const result = topChats
         .map((usage) => {
             const chat = chatDetails.find((c) => c.id === usage.chatId);
-            return chat ? { ...usage, name: chat.name } : null;
+            return chat
+                ? {
+                      ...usage,
+                      _sum: {
+                          inputTokens: usage._sum.inputTokens || 0,
+                          outputTokens: usage._sum.outputTokens || 0,
+                          estimatedCostUsd: Number(usage._sum.estimatedCostUsd || 0),
+                      },
+                      name: chat.name,
+                  }
+                : null;
         })
         .filter(Boolean);
 
@@ -155,6 +184,7 @@ const usageBreakdownByModel = asyncHandler(async (req, res) => {
             SUM(u."input_tokens")::int                              AS "totalInputTokens",
             SUM(u."output_tokens")::int                             AS "totalOutputTokens",
             (SUM(u."input_tokens") + SUM(u."output_tokens"))::int   AS "totalTokens",
+            SUM(u."estimated_cost_usd")::float8                     AS "estimatedCostUsd",
             COUNT(*)::int                                           AS "requestCount"
         FROM "UsageEvents" u
         JOIN "ChatMessage" m ON u."message_id" = m."id"

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -155,6 +155,8 @@ model UsageEvents {
     chatId       String?      @map("chat_id")
     inputTokens  Int          @map("input_tokens")
     outputTokens Int          @map("output_tokens")
+    estimatedCostUsd Decimal   @default(0) @map("estimated_cost_usd") @db.Decimal(12, 6)
+    priceVersion  String?     @map("price_version")
     timestamp    DateTime     @default(now())
     apiKey       ApiKey?      @relation(fields: [apikeyId], references: [id])
     message      ChatMessage? @relation(fields: [messageId], references: [id], onDelete: SetNull)

--- a/backend/utils/constants.js
+++ b/backend/utils/constants.js
@@ -26,6 +26,81 @@ export const PROVIDERS_BASE_URLS = {
 };
 export const MEM0_ENABLED = Boolean(process.env.MEM0_API_KEY);
 
+export const USAGE_PRICING_VERSION = "v1";
+
+// Pricing is expressed as USD per 1M tokens.
+// The values are intentionally conservative and deterministic so the same
+// model/provider pair always maps to the same estimate.
+export const USAGE_PRICING_USD_PER_1M = {
+    DEFAULT: {
+        "default-1": { input: 0.15, output: 0.6 },
+        "default-2": { input: 0.08, output: 0.3 },
+    },
+    OPENAI: {
+        "gpt-5.4": { input: 1.25, output: 10 },
+        "gpt-5.4-mini": { input: 0.25, output: 2 },
+        "gpt-5.4-nano": { input: 0.05, output: 0.4 },
+        "gpt-4o": { input: 5, output: 15 },
+    },
+    ANTHROPIC: {
+        "claude-opus-4-6": { input: 15, output: 75 },
+        "claude-sonnet-4-6": { input: 3, output: 15 },
+        "claude-haiku-4-5": { input: 0.25, output: 1.25 },
+    },
+    GOOGLE: {
+        "gemini-3.1-pro-preview": { input: 1.25, output: 5 },
+        "gemini-3-flash-preview": { input: 0.15, output: 0.6 },
+        "gemini-3.1-flash-lite-preview": { input: 0.05, output: 0.2 },
+    },
+    XAI: {
+        "grok-4-0709": { input: 5, output: 15 },
+        "grok-4.2": { input: 5, output: 15 },
+        "grok-4-fast-reasoning": { input: 2, output: 8 },
+    },
+    OPENROUTER: {
+        "openai/gpt-5.4": { input: 1.25, output: 10 },
+        "openai/gpt-5.4-mini": { input: 0.25, output: 2 },
+        "openai/gpt-5.4-nano": { input: 0.05, output: 0.4 },
+        "openai/gpt-4o-mini": { input: 0.15, output: 0.6 },
+        "anthropic/claude-4.6-opus": { input: 15, output: 75 },
+        "anthropic/claude-4.6-sonnet": { input: 3, output: 15 },
+        "google/gemini-pro-3.1": { input: 1.25, output: 5 },
+        "x-ai/grok-4": { input: 5, output: 15 },
+    },
+};
+
+export const USAGE_PRICING_FALLBACK_USD_PER_1M = {
+    input: 0.5,
+    output: 1.5,
+};
+
+export function resolveUsagePricing(provider, model) {
+    const providerKey = String(provider || "").trim().toUpperCase();
+    const modelKey = String(model || "").trim();
+    const providerPricing = USAGE_PRICING_USD_PER_1M[providerKey];
+
+    if (providerPricing && providerPricing[modelKey]) {
+        return providerPricing[modelKey];
+    }
+
+    return USAGE_PRICING_FALLBACK_USD_PER_1M;
+}
+
+export function estimateUsageCostUsd({ provider, model, inputTokens = 0, outputTokens = 0 }) {
+    const pricing = resolveUsagePricing(provider, model);
+    const inputCost = (Number(inputTokens || 0) / 1_000_000) * pricing.input;
+    const outputCost = (Number(outputTokens || 0) / 1_000_000) * pricing.output;
+    const totalCost = inputCost + outputCost;
+
+    return {
+        inputCostUsd: Number(inputCost.toFixed(6)),
+        outputCostUsd: Number(outputCost.toFixed(6)),
+        estimatedCostUsd: Number(totalCost.toFixed(6)),
+        priceVersion: USAGE_PRICING_VERSION,
+        pricing,
+    };
+}
+
 // Optional tokens limit 
 const parsedDailyTokenBudget = Number(process.env.DAILY_TOKEN_BUDGET);
 export const DAILY_TOKEN_BUDGET =

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -358,7 +358,7 @@ export const exportChatMessages = async (chatId: string): Promise<void> => {
 export const getLifetimeTokens = () =>
     withCache(cacheKey("/usage/lifetime-tokens"), 5 * 60 * 1000, () =>
         apiRequest<{
-            _sum: { inputTokens: number | null; outputTokens: number | null };
+            _sum: { inputTokens: number | null; outputTokens: number | null; estimatedCostUsd: number | null };
         }>("/usage/lifetime-tokens", { method: "GET" }),
     );
 
@@ -371,8 +371,10 @@ export const getTokensByGroup = (groupBy: "day" | "week" | "month" | "year") =>
                     period: string;
                     usageByModels: Array<{
                         model: string;
+                        provider: string | null;
                         totalInput: number;
                         totalOutput: number;
+                        estimatedCostUsd: number;
                     }>;
                 }
             >
@@ -389,18 +391,11 @@ export const getTopChatsByUsage = () =>
         apiRequest<
             Array<{
                 chatId: string;
-                _sum: { inputTokens: number | null; outputTokens: number | null };
+                _sum: { inputTokens: number | null; outputTokens: number | null; estimatedCostUsd: number | null };
                 name?: string | null;
             }>
         >("/usage/top-chats", { method: "GET" }),
     );
-    apiRequest<
-        Array<{
-            chatId: string;
-            _sum: { inputTokens: number | null; outputTokens: number | null };
-            name?: string | null;
-        }>
-    >("/usage/top-chats", { method: "GET" });
 export type UsageBreakdownItem = {
     model: string;
     provider: string | null;
@@ -408,6 +403,32 @@ export type UsageBreakdownItem = {
     totalOutputTokens: number;
     totalTokens: number;
     requestCount: number;
+    estimatedCostUsd: number;
+};
+
+export type AdminUsageSummary = {
+    totalInputTokens: number;
+    totalOutputTokens: number;
+    totalEstimatedCostUsd: number;
+};
+
+export type AdminUsageUserRow = {
+    userId: string | null;
+    username?: string | null;
+    fullname?: string | null;
+    requestCount: number;
+    inputTokens: number;
+    outputTokens: number;
+    estimatedCostUsd: number;
+};
+
+export type AdminUsageModelRow = {
+    model: string;
+    provider: string | null;
+    requestCount: number;
+    inputTokens: number;
+    outputTokens: number;
+    estimatedCostUsd: number;
 };
 
 export const getUsageBreakdown = (params?: {
@@ -432,6 +453,23 @@ export const getUsageBreakdown = (params?: {
         };
     }>(`/usage/breakdown${query ? `?${query}` : ""}`, { method: "GET" });
 };
+
+export const getAdminOverview = () =>
+    apiRequest<{
+        totalUsers: number;
+        totalInputTokens: number;
+        totalOutputTokens: number;
+        totalEstimatedCostUsd: number;
+    }>("/admin/overview", { method: "GET" });
+
+export const getAdminUsage = () =>
+    apiRequest<{
+        totalInputTokens: number;
+        totalOutputTokens: number;
+        totalEstimatedCostUsd: number;
+        topUsersByTokenUsage: AdminUsageUserRow[];
+        topModelsByTokenUsage: AdminUsageModelRow[];
+    }>("/admin/usage", { method: "GET" });
 
 export const toggleChatShare = (chatId: string) =>
     apiRequest<ChatItem>(`/chat/${chatId}/share`, { method: "POST" });

--- a/src/pages/Usage.tsx
+++ b/src/pages/Usage.tsx
@@ -22,8 +22,10 @@ type UsagePoint = {
     period: string;
     usageByModels: Array<{
         model: string;
+        provider: string | null;
         totalInput: number;
         totalOutput: number;
+        estimatedCostUsd: number;
     }>;
 };
 
@@ -89,6 +91,7 @@ export const Usage = () => {
     const [timeframe, setTimeframe] = useState<Timeframe>("month");
     const [usagePoints, setUsagePoints] = useState<UsagePoint[]>([]);
     const [lifetimeTotal, setLifetimeTotal] = useState(0);
+    const [lifetimeCost, setLifetimeCost] = useState(0);
     const [apiKeyCount, setApiKeyCount] = useState(0);
     const [topChats, setTopChats] = useState<Array<{ name: string; tokens: number; color: string }>>([]);
     const [error, setError] = useState("");
@@ -126,6 +129,7 @@ export const Usage = () => {
                 const input = lifetime?._sum?.inputTokens || 0;
                 const output = lifetime?._sum?.outputTokens || 0;
                 setLifetimeTotal(input + output);
+                setLifetimeCost(Number(lifetime?._sum?.estimatedCostUsd || 0));
                 setApiKeyCount(keys.count || 0);
 
                 const ranked = [...(topChatsByUsage || [])]
@@ -342,6 +346,16 @@ export const Usage = () => {
                         </div>
                     </div>
 
+                    <div className="grid grid-cols-1 md:grid-cols-2 gap-5">
+                        <div className="p-6 rounded-xl bg-white/2 border border-white/5">
+                            <p className="text-sm font-medium text-gray-400">Estimated Lifetime Cost</p>
+                            <h3 className="text-3xl font-bold text-white mt-2">${lifetimeCost.toFixed(4)}</h3>
+                            <p className="text-xs text-gray-500 font-medium mt-2">
+                                Deterministic estimate stored on usage events
+                            </p>
+                        </div>
+                    </div>
+
                     <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
                         {/* Token Usage Chart */}
                         <div className="lg:col-span-2 p-6 rounded-xl bg-white/2 border border-white/5 flex flex-col">
@@ -425,6 +439,7 @@ export const Usage = () => {
                                             <th className="text-left pb-3 font-medium">Provider</th>
                                             <th className="text-right pb-3 font-medium">Input</th>
                                             <th className="text-right pb-3 font-medium">Output</th>
+                                            <th className="text-right pb-3 font-medium">Cost</th>
                                             <th className="text-right pb-3 font-medium">Total</th>
                                             <th className="text-right pb-3 font-medium">Requests</th>
                                         </tr>
@@ -436,6 +451,7 @@ export const Usage = () => {
                                                 <td className="py-3 text-gray-400">{item.provider || "—"}</td>
                                                 <td className="py-3 text-right text-gray-300">{formatTokens(item.totalInputTokens)}</td>
                                                 <td className="py-3 text-right text-gray-300">{formatTokens(item.totalOutputTokens)}</td>
+                                                <td className="py-3 text-right text-gray-300">${item.estimatedCostUsd.toFixed(4)}</td>
                                                 <td className="py-3 text-right font-semibold text-white">{formatTokens(item.totalTokens)}</td>
                                                 <td className="py-3 text-right text-gray-400">{item.requestCount}</td>
                                             </tr>


### PR DESCRIPTION
## Summary

Adds estimated USD cost accounting to usage tracking by calculating and storing cost at usage-event creation time.

## Changes

### Backend

* Added `estimatedCostUsd` and `priceVersion` fields to `UsageEvents`
* Added deterministic model/provider pricing configuration
* Added pricing helper utilities for cost estimation
* Compute and persist estimated cost when usage events are created
* Extended usage APIs to return cost aggregates and breakdowns

### Frontend

* Updated usage API types to include cost fields
* Added estimated cost display to the Usage page
* Added cost information alongside existing token metrics

## Cost Calculation

* Cost is calculated using a provider/model pricing map
* Unknown models use a documented fallback pricing rule
* Pricing version is stored with each usage event for consistency

## Verification

* Prisma schema validation passed
* Backend syntax validation passed for all modified files

## Notes

* Cost values are estimates intended for operational visibility and budgeting.
* Cost is calculated at write time so usage queries remain efficient.

Closes #64
