### PR TITLE
feat: surface failed ingestion runs in dashboard

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -79,6 +79,25 @@ export type ChatMessageSourceItem = {
     score: number;
 };
 
+export type FailedIngestionRunItem = {
+    id: string;
+    chatId: string;
+    chatSourceId?: string | null;
+    status: string;
+    startedAt: string;
+    finishedAt?: string | null;
+    errorCode?: string | null;
+    errorMessage?: string | null;
+    chat?: {
+        name?: string | null;
+        userId?: string | null;
+    };
+    chatSource?: {
+        heading?: string | null;
+        documentationUrl?: string | null;
+    };
+};
+
 const apiRequest = async <T>(path: string, init?: RequestInit): Promise<T> => {
     const headers = new Headers(init?.headers || {});
     if (!headers.has("Content-Type") && init?.body) {
@@ -206,6 +225,12 @@ export const getApiKeyCount = () => apiRequest<{ count: number }>("/apikey/count
 export const getChats = () =>
     withCache(cacheKey("/chat/list"), 5 * 60 * 1000, () =>
         apiRequest<ChatItem[]>("/chat/list", { method: "GET" }),
+    );
+
+export const getRecentFailedIngestionRuns = (limit = 5) =>
+    apiRequest<{ runs: FailedIngestionRunItem[] }>(
+        `/chat/ingestion-runs/failed?limit=${limit}`,
+        { method: "GET" },
     );
 
 export const createChat = async (payload: {

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -22,9 +22,11 @@ import {
     getChatStatus,
     getLifetimeTokens,
     getRecentChats,
+    getRecentFailedIngestionRuns,
     invalidatePagesIndexed,
     cancelChat,
     type ChatItem,
+    type FailedIngestionRunItem,
 } from "../lib/api";
 import { formatTokens } from "../lib/format";
 
@@ -94,6 +96,7 @@ const Dashboard = () => {
     const [isDeleting, setIsDeleting] = useState(false);
     const [isCancelling, setIsCancelling] = useState(false);
     const [lifetimeTokens, setLifetimeTokens] = useState(0);
+    const [failedRuns, setFailedRuns] = useState<FailedIngestionRunItem[]>([]);
     const [chatProgress, setChatProgress] = useState<
         Record<string, { status: string; progress: number }>
     >({});
@@ -126,6 +129,14 @@ const Dashboard = () => {
             const input = Number(lifetime?._sum?.inputTokens || 0);
             const output = Number(lifetime?._sum?.outputTokens || 0);
             setLifetimeTokens(input + output);
+
+            try {
+                const failedRunResponse = await getRecentFailedIngestionRuns(5);
+                setFailedRuns(failedRunResponse?.runs || []);
+            } catch (failedRunError) {
+                console.error("Failed to load failed ingestion runs:", failedRunError);
+                setFailedRuns([]);
+            }
         } catch (err) {
             setError(err instanceof Error ? err.message : "Failed to load dashboard data.");
         } finally {
@@ -440,6 +451,11 @@ const Dashboard = () => {
                                     </button>
                                 ),
                             },
+                            {
+                                label: "Failed Ingestions",
+                                value: failedRuns.length.toString(),
+                                icon: <AlertCircle className="w-5 h-5 text-red-400" />,
+                            },
                         ].map((stat, i) => (
                             <div
                                 key={i}
@@ -455,6 +471,58 @@ const Dashboard = () => {
                                 </div>
                             </div>
                         ))}
+                    </div>
+
+                    {/* Failed Ingestions Section */}
+                    <div className="rounded-2xl border border-white/5 bg-white/2 p-5">
+                        <div className="flex items-center justify-between mb-5 gap-4">
+                            <div>
+                                <h2 className="text-lg font-semibold">Recent Failed Ingestions</h2>
+                                <p className="text-sm text-gray-400">
+                                    Review the latest ingestion runs that did not complete successfully.
+                                </p>
+                            </div>
+                            <div className="text-sm text-gray-400">
+                                {failedRuns.length} recent failure{failedRuns.length === 1 ? "" : "s"}
+                            </div>
+                        </div>
+
+                        {failedRuns.length > 0 ? (
+                            <div className="grid gap-3">
+                                {failedRuns.slice(0, 3).map((run) => (
+                                    <div
+                                        key={run.id}
+                                        className="rounded-2xl border border-white/5 bg-[#0d0d12] p-4"
+                                    >
+                                        <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-3">
+                                            <div>
+                                                <p className="text-sm font-semibold text-white truncate">
+                                                    {run.chat?.name || run.chatId}
+                                                </p>
+                                                <p className="text-xs text-gray-500 mt-1">
+                                                    {run.chatSource?.heading || run.chatSourceId || "No source"}
+                                                </p>
+                                            </div>
+                                            <div className="text-right">
+                                                <p className="text-xs uppercase text-red-400 tracking-[0.2em] font-semibold">
+                                                    {run.status}
+                                                </p>
+                                                <p className="text-xs text-gray-500 mt-1">
+                                                    {fromNow(run.startedAt)}
+                                                </p>
+                                            </div>
+                                        </div>
+                                        <div className="mt-4 rounded-xl bg-white/5 p-3 text-sm text-gray-300 border border-white/5">
+                                            {run.errorMessage || run.errorCode || "Unknown ingestion failure."}
+                                        </div>
+                                    </div>
+                                ))}
+                            </div>
+                        ) : (
+                            <div className="rounded-2xl border border-dashed border-white/10 bg-[#0b0b0f] p-6 text-center text-sm text-gray-400">
+                                No recent failed ingestion runs were found.
+                            </div>
+                        )}
                     </div>
 
                     {/* Chat List Section */}


### PR DESCRIPTION
## Summary

Adds dashboard visibility for failed ingestion runs using the existing `GET /chat/ingestion-runs/failed` endpoint.

## Changes

### API

* Added `FailedIngestionRunItem` type
* Added `getRecentFailedIngestionRuns(limit)` helper

### Dashboard

* Added failed-ingestion state management
* Fetches recent failed ingestion runs alongside dashboard data
* Displays a compact "Recent Failed Ingestions" section
* Shows:

  * chat name / chat id
  * source information
  * failure reason
  * ingestion status
  * relative timestamp

### Resilience

* Failed-ingestion fetching is isolated in its own `try/catch`
* Dashboard continues to render even if the failed-ingestion endpoint is unavailable
* Failed endpoint errors do not affect existing dashboard functionality

## Validation

* Verified failed-ingestion endpoint integration
* Verified dashboard rendering with and without failed runs
* Production build completed successfully

Closes #144