### PR TITLE
feat: support soft-deletion for chats

### DIFF
--- a/backend/controllers/chat.controller.js
+++ b/backend/controllers/chat.controller.js
@@ -258,10 +258,15 @@ const progressStatus = asyncHandler(async (req, res) => {
             status: true,
             failedAt: true,
             failureReason: true,
+            deletedAt: true,
         },
     });
 
     if (!chat) {
+        throw new ApiError(404, "Chat not found");
+    }
+
+    if (chat.deletedAt) {
         throw new ApiError(404, "Chat not found");
     }
 
@@ -318,10 +323,14 @@ const streamChatStatus = asyncHandler(async (req, res) => {
             id: chatId,
             userId: req.user.id,
         },
-        select: { id: true },
+        select: { id: true, deletedAt: true },
     });
 
     if (!chat) {
+        throw new ApiError(404, "Chat not found");
+    }
+
+    if (chat.deletedAt) {
         throw new ApiError(404, "Chat not found");
     }
 
@@ -438,7 +447,7 @@ const qdrantCleanup = asyncHandler(async (req, res) => {
 
 const listAllChats = asyncHandler(async (req, res) => {
     const chats = await prisma.chat.findMany({
-        where: { userId: req.user.id },
+        where: { userId: req.user.id, deletedAt: null },
         include: {
             chatSources: {
                 include: {
@@ -486,7 +495,7 @@ const listAllChats = asyncHandler(async (req, res) => {
 
 const recentChats = asyncHandler(async (req, res) => {
     const chats = await prisma.chat.findMany({
-        where: { userId: req.user.id },
+        where: { userId: req.user.id, deletedAt: null },
         include: {
             chatSources: {
                 include: {
@@ -548,6 +557,14 @@ const chatDetails = asyncHandler(async (req, res) => {
         },
     });
 
+    if (!chat) {
+        throw new ApiError(404, "Chat not found");
+    }
+
+    if (chat.deletedAt) {
+        throw new ApiError(404, "Chat not found");
+    }
+
     res.status(200).json(new ApiResponse(200, { chat }, "Chat details fetched successfully"));
 });
 
@@ -564,6 +581,14 @@ const listAllPagesIndexed = asyncHandler(async (req, res) => {
             },
         },
     });
+
+    if (!chat) {
+        throw new ApiError(404, "Chat not found");
+    }
+
+    if (chat.deletedAt) {
+        throw new ApiError(404, "Chat not found");
+    }
 
     res.status(200).json(
         new ApiResponse(
@@ -584,6 +609,10 @@ const cancelProcessing = asyncHandler(async (req, res) => {
     });
 
     if (!chat) {
+        throw new ApiError(404, "Chat not found");
+    }
+
+    if (chat.deletedAt) {
         throw new ApiError(404, "Chat not found");
     }
 
@@ -616,6 +645,7 @@ const deleteChat = asyncHandler(async (req, res) => {
         select: {
             id: true,
             userId: true,
+            deletedAt: true,
         },
     });
 
@@ -627,30 +657,58 @@ const deleteChat = asyncHandler(async (req, res) => {
         throw new ApiError(403, "You do not have permission to delete this chat");
     }
 
-    await prisma.$transaction(async (tx) => {
-        await tx.chatMessageSource.deleteMany({
-            where: { chatMessage: { chatId } },
-        });
+    if (chat.deletedAt) {
+        throw new ApiError(400, "Chat is already deleted");
+    }
 
-        await tx.chatMessage.deleteMany({
-            where: { chatId },
-        });
-
-        await tx.chat.delete({
-            where: { id: chatId },
-        });
-
-        // ChatSource rows (and their DocumentTree / DocumentPage children) are
-        // intentionally left intact — they may be shared by other chats, and the
-        // Qdrant collection they reference is preserved so no data is lost.
-        // Orphaned collections are cleaned up by the admin Qdrant sweep.
+    await prisma.chat.update({
+        where: { id: chatId },
+        data: { deletedAt: new Date() },
     });
+
+    await createAuditEvent("chat.deleted", req.user.id, chatId, {});
 
     res.status(200).json(
         new ApiResponse(200, null, "Chat deleted successfully"),
     );
 });
 
+
+const restoreChat = asyncHandler(async (req, res) => {
+    const { chatId } = req.params;
+
+    const chat = await prisma.chat.findUnique({
+        where: { id: chatId },
+        select: {
+            id: true,
+            userId: true,
+            deletedAt: true,
+        },
+    });
+
+    if (!chat) {
+        throw new ApiError(404, "Chat not found");
+    }
+
+    if (chat.userId !== req.user.id) {
+        throw new ApiError(403, "You do not have permission to restore this chat");
+    }
+
+    if (!chat.deletedAt) {
+        throw new ApiError(400, "Chat is not deleted");
+    }
+
+    await prisma.chat.update({
+        where: { id: chatId },
+        data: { deletedAt: null },
+    });
+
+    await createAuditEvent("chat.restored", req.user.id, chatId, {});
+
+    res.status(200).json(
+        new ApiResponse(200, null, "Chat restored successfully"),
+    );
+});
 
 const toggleShare = asyncHandler(async (req, res) => {
     const { chatId } = req.params;
@@ -661,6 +719,10 @@ const toggleShare = asyncHandler(async (req, res) => {
 
     if (!chat) {
         throw new ApiError(404, "Chat not found");
+    }
+
+    if (chat.deletedAt) {
+        throw new ApiError(400, "Cannot share a deleted chat");
     }
 
     if (chat.shareToken) {
@@ -781,6 +843,7 @@ export {
     chatDetails,
     cancelProcessing,
     deleteChat,
+    restoreChat,
     listAllPagesIndexed,
     recentChats,
     toggleShare,

--- a/backend/prisma/migrations/20260612_add_deleted_at_to_chat/migration.sql
+++ b/backend/prisma/migrations/20260612_add_deleted_at_to_chat/migration.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "Chat" ADD COLUMN "deleted_at" TIMESTAMP(3);

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -56,6 +56,7 @@ model Chat {
     failureReason  String?       @map("failure_reason")
     collectionName String?       @map("collection_name")
     shareToken     String?       @unique @map("share_token")
+    deletedAt      DateTime?     @map("deleted_at")
     createdBy      User          @relation(fields: [userId], references: [id])
     chatSources    ChatSource[]  @relation("ChatToChatSource")
     messages       ChatMessage[]

--- a/backend/routers/chat.route.js
+++ b/backend/routers/chat.route.js
@@ -13,6 +13,7 @@ import {
     chatDetails,
     createChat,
     deleteChat,
+    restoreChat,
     expectation,
     listAllChats,
     recentChats,
@@ -60,5 +61,8 @@ chatRouter
 chatRouter
     .route("/cancel/:chatId")
     .get(verifyStrictJWT, validate(chatIdParamSchema), verifyChatOwnership, cancelProcessing);
+chatRouter
+    .route("/restore/:chatId")
+    .post(verifyStrictJWT, validate(chatIdParamSchema), verifyChatOwnership, restoreChat);
 
 export default chatRouter;


### PR DESCRIPTION
Closes #159

### Summary
Replace hard chat deletion with soft deletion so users can restore chats accidentally removed from the dashboard.

### Changes

**`backend/prisma/schema.prisma`**
- Added `deletedAt DateTime?` field to Chat model

**`backend/prisma/migrations/20260612_add_deleted_at_to_chat/migration.sql`**
- Migration: `ALTER TABLE "Chat" ADD COLUMN "deleted_at" TIMESTAMP(3)`

**`backend/controllers/chat.controller.js`**
- `deleteChat` now sets `deletedAt` instead of removing the row (preserves messages, sources, usage data)
- Added `restoreChat` handler — `POST /chat/restore/:chatId` clears `deletedAt`
- `listAllChats`, `recentChats` filter with `deletedAt: null` (deleted chats hidden by default)
- `progressStatus`, `streamChatStatus`, `chatDetails`, `listAllPagesIndexed`, `cancelProcessing`, `toggleShare` all reject deleted chats with 404/400
- Audit events emitted for both `chat.deleted` and `chat.restored`

**`backend/routers/chat.route.js`**
- Added `POST /chat/restore/:chatId` route with JWT + ownership validation