### PR TITLE
 Store indexed pages for vectorless ingestion (DocumentPage)

### DIFF
--- a/backend/chatWorker.js
+++ b/backend/chatWorker.js
@@ -285,6 +285,8 @@ async function processVectorLess(docsRootUrl, chatId, chatSourceId, scrapeLimit)
         await redis.setex(getChatProgressKey(chatId), 3600, JSON.stringify({ status: "READY", progress: 100 }));
         await updateChatProgress(chatId, { status: "READY", progress: 100 });
 
+        const actualPages = pages.length;
+
         await prisma.chat.update({
             where: { id: chatId },
             data: {
@@ -293,7 +295,10 @@ async function processVectorLess(docsRootUrl, chatId, chatSourceId, scrapeLimit)
                 chatSources: {
                     update: {
                         where: { id: chatSourceId },
-                        data: { collectionName: docTree.id },
+                        data: {
+                            collectionName: docTree.id,
+                            totalPages: actualPages,
+                        },
                     },
                 },
             },


### PR DESCRIPTION
Closes #42

### Summary
Vectorless ingestion now creates `DocumentPage` rows for each successfully scraped URL, and updates `ChatSource.totalPages` to match the actual count so the UI shows correct page lists and counts without special-casing.

### Changes

**`backend/chatWorker.js`** — `processVectorLess`
- After tree generation and `DocumentPage` batch insert, updates `ChatSource.totalPages` to the actual number of successfully scraped pages (instead of the initial link estimate)
- The `DocumentPage.createMany` (with `pageUrl`, `heading`, `startIndex`, `endIndex`) was already present in the vectorless path — this fix ensures `totalPages` lines up with the `_count.pagesIndexed` that the UI reads, so the "Show all pages" feature works uniformly for both vector and vectorless chats