### PR TITLE
fix: prevent premature admin redirects

### DIFF
--- a/src/components/ProtectedRoute.tsx
+++ b/src/components/ProtectedRoute.tsx
@@ -38,7 +38,7 @@ export const ProtectedRoute = ({ children, adminOnly = false }: Props) => {
 
     if (adminOnly) {
         const sessionAdmin = Boolean(getAuthUser()?.isAdmin);
-        if (isAdmin === false || (!sessionAdmin && isAdmin === null)) {
+        if (isAdmin === false) {
             return <Navigate to="/dashboard" replace />;
         }
         if (isAdmin === null && !sessionAdmin) {


### PR DESCRIPTION
## Summary

Fixes the admin route guard race condition in `ProtectedRoute`.

## Changes

* Removed the premature redirect condition that triggered while `isAdmin` was still `null`.
* Kept loading-state behavior while admin verification is pending.
* Preserved redirect behavior for confirmed non-admin users (`isAdmin === false`).

## Why

Previously, administrators could be redirected to `/dashboard` before the asynchronous profile check completed, preventing access to admin routes.

## Validation

* Verified pending admin checks remain in the loading state.
* Verified non-admin users are redirected after verification.
* Verified administrators can access protected admin routes after profile resolution.

Closes #209
