### PR TITLE
feat: add hasSystemInstructions metadata flag to message history resp…

### DIFF
--- a/backend/controllers/chatMessage.controller.js
+++ b/backend/controllers/chatMessage.controller.js
@@ -359,6 +359,7 @@ const getChatMessages = asyncHandler(async (req, res) => {
     const messages = await prisma.chatMessage.findMany({
         where: { chatId },
         orderBy: { createdAt: "asc" },
+        include: { chatMessageSources: true },
     });
 
     if (!messages.length) {
@@ -367,9 +368,14 @@ const getChatMessages = asyncHandler(async (req, res) => {
             .json(new ApiResponse(200, { messages: [] }, "No messages found for this chat."));
     }
 
+    const messagesWithMeta = messages.map(({ chatMessageSources, ...msg }) => ({
+        ...msg,
+        hasSystemInstructions: chatMessageSources.length > 0,
+    }));
+
     return res
         .status(200)
-        .json(new ApiResponse(200, { messages: messages }, "Chat messages retrieved successfully."));
+        .json(new ApiResponse(200, { messages: messagesWithMeta }, "Chat messages retrieved successfully."));
 });
 
 
@@ -534,6 +540,7 @@ const getSharedChatMessages = asyncHandler(async (req, res) => {
     const messages = await prisma.chatMessage.findMany({
         where: { chatId: chat.id },
         orderBy: { createdAt: "asc" },
+        include: { chatMessageSources: true },
     });
 
     if (!messages.length) {
@@ -542,9 +549,14 @@ const getSharedChatMessages = asyncHandler(async (req, res) => {
             .json(new ApiResponse(200, { messages: [] }, "No messages found for this chat."));
     }
 
+    const messagesWithMeta = messages.map(({ chatMessageSources, ...msg }) => ({
+        ...msg,
+        hasSystemInstructions: chatMessageSources.length > 0,
+    }));
+
     return res
         .status(200)
-        .json(new ApiResponse(200, { messages: messages }, "Chat messages retrieved successfully."));
+        .json(new ApiResponse(200, { messages: messagesWithMeta }, "Chat messages retrieved successfully."));
 });
 
 export {


### PR DESCRIPTION
## Summary
Adds a `hasSystemInstructions` boolean metadata field to message history responses so the frontend can tell whether system instructions with documentation context were used during answer generation.

## Changes
- Updated `getChatMessages` to include `hasSystemInstructions` in each message response
- Updated `getSharedChatMessages` with the same change
- No database schema changes — flag is derived at the serialization layer

## Note
I've made the changes. One thing to note — since `hasSystemInstructions` isn't stored in the database, I derived it at the serialization layer by checking whether the message has any `chatMessageSources` attached. The assumption is that if sources exist, system instructions with documentation context were used; if not, it fell back to the general answer prompt. Let me know if you'd like a different approach!

## Closes #151