### PR TITLE
feat: add raw source download endpoint for ChatSource content (#160)

### DIFF
--- a/backend/controllers/chat.controller.js
+++ b/backend/controllers/chat.controller.js
@@ -9,6 +9,7 @@ import crypto from "crypto";
 import { createAuditEvent } from "../utils/audit.js";
 import { normalizeUrl } from "../utils/ragUtilities.js";
 import { getChatCreationQueue } from "../utils/queue.js";
+import { qdrant } from "../utils/ragClients.js";
 
 const normalizeDocsUrl = (docsUrl) => normalizeUrl(docsUrl);
 
@@ -970,6 +971,63 @@ const forkSharedChat = asyncHandler(async (req, res) => {
     );
 });
 
+const downloadRawSource = asyncHandler(async (req, res) => {
+    const { chatId, sourceId } = req.params;
+
+    const chatSource = await prisma.chatSource.findFirst({
+        where: {
+            id: sourceId,
+            chats: { some: { id: chatId } }
+        },
+        include: {
+            documentTree: true
+        }
+    });
+
+    if (!chatSource) {
+        throw new ApiError(404, "Source not found or does not belong to this chat");
+    }
+
+    let rawText = "";
+
+    if (chatSource.isVectorLess) {
+        if (!chatSource.documentTree?.sourceData) {
+            throw new ApiError(404, "Raw source data not available yet");
+        }
+        rawText = chatSource.documentTree.sourceData;
+    } else {
+        if (!chatSource.collectionName) {
+            throw new ApiError(404, "Vector collection not initialized");
+        }
+
+        let nextOffset = null;
+        do {
+            const response = await qdrant.scroll(chatSource.collectionName, {
+                filter: {
+                    must: [{ key: "chatSourceId", match: { value: sourceId } }]
+                },
+                limit: 1000,
+                offset: nextOffset
+            });
+
+            for (const point of response.points) {
+                rawText += `--- ${point.payload.title || 'Page'} (${point.payload.url}) ---\n`;
+                rawText += `${point.payload.body}\n\n`;
+            }
+
+            nextOffset = response.next_page_offset;
+        } while (nextOffset);
+
+        if (!rawText) {
+            throw new ApiError(404, "No raw text found in the vector database");
+        }
+    }
+
+    res.setHeader('Content-Type', 'text/plain');
+    res.setHeader('Content-Disposition', `attachment; filename="source-${sourceId}-raw.txt"`);
+    res.send(rawText);
+});
+
 export {
     expectation,
     createChat,
@@ -989,4 +1047,5 @@ export {
     toggleShare,
     getSharedChatDetails,
     forkSharedChat,
+    downloadRawSource,
 };

--- a/backend/routers/chat.route.js
+++ b/backend/routers/chat.route.js
@@ -28,6 +28,7 @@ import {
     forkSharedChat,
     qdrantCleanup,
     streamChatStatus,
+    downloadRawSource,
 } from "../controllers/chat.controller.js";
 
 const chatRouter = Router();
@@ -62,6 +63,9 @@ chatRouter
 chatRouter
     .route("/pages-indexed/:chatId")
     .get(verifyStrictJWT, validate(chatIdParamSchema), verifyChatOwnership, listAllPagesIndexed);
+chatRouter
+    .route("/:chatId/sources/:sourceId/raw")
+    .get(verifyStrictJWT, validate(chatIdParamSchema), verifyChatOwnership, downloadRawSource);
 chatRouter
     .route("/:chatId")
     .delete(verifyStrictJWT, validate(chatIdParamSchema), verifyChatOwnership, deleteChat);

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -439,6 +439,44 @@ export const exportChatMessages = async (chatId: string): Promise<void> => {
     URL.revokeObjectURL(url);
 };
 
+export const exportRawSource = async (chatId: string, sourceId: string): Promise<void> => {
+    const token = getAccessToken();
+    const headers = new Headers();
+    if (token) {
+        headers.set("Authorization", `Bearer ${token}`);
+    }
+
+    const response = await fetch(`${API_BASE_URL}/chat/${chatId}/sources/${sourceId}/raw`, {
+        method: "GET",
+        headers,
+        credentials: "include",
+    });
+
+    if (!response.ok) {
+        throw new Error("Failed to export raw source");
+    }
+
+    // Try to get filename from Content-Disposition if present
+    let filename = `source-${sourceId}-raw.txt`;
+    const disposition = response.headers.get('Content-Disposition');
+    if (disposition && disposition.includes('filename=')) {
+        const match = disposition.match(/filename="?([^"]+)"?/);
+        if (match && match[1]) {
+            filename = match[1];
+        }
+    }
+
+    const blob = await response.blob();
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = filename;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+};
+
 export const getLifetimeTokens = () =>
     withCache(cacheKey("/usage/lifetime-tokens"), 5 * 60 * 1000, () =>
         apiRequest<{

--- a/src/pages/ChatPage.tsx
+++ b/src/pages/ChatPage.tsx
@@ -59,11 +59,13 @@ import {
     getPagesIndexed,
     sendMessageStream,
     exportChatMessages,
+    exportRawSource,
     toggleChatShare,
 } from "../lib/api";
 import { formatTokens } from "../lib/format";
 
 type CurrentLink = {
+    id?: string;
     title: string;
     url: string;
     isHighlight: boolean;
@@ -158,6 +160,7 @@ export const ChatPage = () => {
     const [sourceFetchAttempted, setSourceFetchAttempted] = useState(false);
 
     const [isExporting, setIsExporting] = useState(false);
+    const [isExportingSources, setIsExportingSources] = useState(false);
     const [isIndexedModalOpen, setIsIndexedModalOpen] = useState(false);
     const [currentLinks, setCurrentLinks] = useState<CurrentLink[]>([]);
     const [indexedPages, setIndexedPages] = useState<IndexedPage[]>([]);
@@ -197,6 +200,23 @@ export const ChatPage = () => {
         }
     };
 
+    const handleDownloadAllSources = async () => {
+        if (isExportingSources || currentLinks.length === 0) return;
+        setIsExportingSources(true);
+        try {
+            for (const link of currentLinks) {
+                if (link.id) {
+                    await exportRawSource(chatId, link.id);
+                    await new Promise(res => setTimeout(res, 500));
+                }
+            }
+        } catch (err) {
+            setError(err instanceof Error ? err.message : "Failed to download raw sources.");
+        } finally {
+            setIsExportingSources(false);
+        }
+    };
+
     const loadChatPage = async () => {
         if (!chatId) return;
         setIsPageLoading(true);
@@ -229,6 +249,7 @@ export const ChatPage = () => {
             setCurrentLinks(
                 (chat?.chatSources || [])
                     .map((source) => ({
+                        id: source.id,
                         title: source.documentationUrl,
                         url: source.documentationUrl,
                         isHighlight: false,
@@ -685,9 +706,23 @@ export const ChatPage = () => {
 
                             {/* Scraped Pages List */}
                             <div className="flex-1 overflow-y-auto p-4 w-70">
-                                <h4 className="text-sm font-bold text-gray-500 uppercase tracking-wider mb-3">
-                                    Current Links
-                                </h4>
+                                <div className="flex items-center justify-between mb-3">
+                                    <h4 className="text-sm font-bold text-gray-500 uppercase tracking-wider">
+                                        Current Links
+                                    </h4>
+                                    {currentLinks.length > 0 && (
+                                        <button
+                                            type="button"
+                                            onClick={handleDownloadAllSources}
+                                            disabled={isExportingSources}
+                                            className="text-[10px] uppercase tracking-wide bg-white/5 hover:bg-white/10 text-gray-300 hover:text-white px-2 py-1 rounded border border-white/10 font-semibold flex items-center gap-1.5 transition-colors disabled:opacity-50"
+                                            title="Download all raw sources"
+                                        >
+                                            <Download className="w-3 h-3 text-accent-blue" />
+                                            {isExportingSources ? "Wait..." : "Raw Data"}
+                                        </button>
+                                    )}
+                                </div>
                                 <div className="space-y-1 mb-4">
                                     {currentLinks.length > 0 ? (
                                         currentLinks.map((page, i) => (


### PR DESCRIPTION
# Add a raw source download endpoint for ChatSource content

Fixes #160

## Summary
When retrieval quality looks wrong, the raw extracted text is often the fastest way to understand whether the scraper, cleaner, or chunking step dropped important content. This PR introduces a new secure endpoint that allows chat owners to download the raw scraped source text behind a `ChatSource` for debugging and review.

## Changes
- **New Endpoint (`GET /:chatId/sources/:sourceId/raw`)**: Added to `backend/routers/chat.route.js`.
- **Strict Ownership Validation**: Wrapped the route in the existing `verifyChatOwnership` and `verifyStrictJWT` middlewares to ensure only authenticated owners can access their source data.
- **Vector-less Source Support**: For non-vectorized sources, the unbroken text is securely pulled directly from the Postgres `DocumentTree` table.
- **Vector-based Source Support**: For vector-based sources, we dynamically stitch together the `body` payloads using the `qdrant.scroll` API to retrieve all scraped chunks seamlessly, formatting them with the source page title and URL.
- **File Download**: The response includes `Content-Type: text/plain` and an appropriate `Content-Disposition` header to trigger an immediate file download on the client.

## Acceptance Criteria Met
- [x] Authenticated owners can download the raw scraped content for a source.
- [x] The endpoint validates ownership before returning any content.
- [x] The download is returned as plain text.

## Implementation Details
- Handled Qdrant's pagination using the `offset` parameter in the `scroll` API to ensure we collect all chunks regardless of source size.
- Pre-checks `collectionName` and `sourceData` existences to gracefully return `404` errors if the backend hasn't generated the data yet.
