### PR TITLE
fix: correct chat source cleanup during user deletion

### DIFF
--- a/backend/controllers/user.controller.js
+++ b/backend/controllers/user.controller.js
@@ -374,22 +374,40 @@ const deleteMyData = asyncHandler(async (req, res) => {
         })
       ).map((c) => c.id);
 
-      // Find ChatSource IDs used by this user's chats
+      // Find ChatSources used by this user's chats
       const userChatSources = await tx.chatSource.findMany({
-        where: { chatId: { in: userChatIds } },
-        select: { id: true, docsUrl: true },
+        where: {
+          chats: {
+            some: {
+              id: {
+                in: userChatIds,
+              },
+            },
+          },
+        },
+        select: {
+          id: true,
+          documentationUrl: true,
+        },
       });
 
-      // Only delete ChatSources not referenced by any other chat
+      // Only delete ChatSources not referenced by any other user's chats
       for (const cs of userChatSources) {
         const otherChatCount = await tx.chat.count({
           where: {
-            chatSources: { some: { docsUrl: cs.docsUrl } },
             userId: { not: userId },
+            chatSources: {
+              some: {
+                documentationUrl: cs.documentationUrl,
+              },
+            },
           },
         });
+
         if (otherChatCount === 0) {
-          await tx.chatSource.delete({ where: { id: cs.id } });
+          await tx.chatSource.delete({
+            where: { id: cs.id },
+          });
         }
       }
 


### PR DESCRIPTION
## Description

This PR fixes Prisma relation and field reference bugs in the `deleteMyData` transaction within `backend/controllers/user.controller.js`.

### Changes made

* Replaced the invalid `chatId` filter on `ChatSource` with a proper relation-based query using `chats.some.id`.
* Replaced all incorrect `docsUrl` references with the correct Prisma field `documentationUrl`.
* Preserved the existing safe-cleanup behavior by deleting `ChatSource` records only when they are not referenced by any other user's chats.
* Improved readability of the cleanup logic without changing the intended deletion flow.

Fixes #212

## Type of Change

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] Refactoring (structural code cleanups with no behavior changes)
* [ ] Performance improvement (indexing speed, search latency, UI responsiveness)
* [ ] Documentation update (non-executable reference upgrades)

## Checklist

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings or console errors
* [ ] I have run tests locally (`pnpm run test` or `vitest run` under `backend/`) and they pass
* [ ] Any dependent changes have been merged and published in downstream modules

## Verification Details

1. Verified there are no remaining `docsUrl` references in `backend/controllers/user.controller.js`.
2. Confirmed `ChatSource` lookup now uses the `chats` relation (`chats.some.id`).
3. Confirmed cleanup logic uses the correct `documentationUrl` field.
4. Ran syntax validation:

   * `node --check backend/controllers/user.controller.js`
5. Ran frontend build:

   * `npm run build`

### Expected Result

* User data deletion completes successfully without Prisma relation or field errors.
* User-owned chats and related data can be deleted without server crashes.
* Shared `ChatSource` records are preserved when referenced by other users.

## Visual Documentation

Not applicable. This PR contains backend-only changes and does not introduce UI modifications.
