### PR TITLE
fix(settings): remove duplicate delete button from API keys list (#210)

### DIFF
--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -352,13 +352,6 @@ const Settings = () => {
                                             >
                                                 <Edit2 className="w-4 h-4" />
                                             </button>
-                                            <button
-                                                onClick={() => handleDeleteKey(key.id)}
-                                                className="p-2 bg-red-500/10 text-red-400 rounded-lg hover:bg-red-500/20 transition-colors"
-                                                title="Delete Key"
-                                            >
-                                                <Trash2 className="w-4 h-4" />
-                                            </button>
                                         </div>
                                     </div>
                                 ))


### PR DESCRIPTION
## Description

Removes the redundant duplicate delete button rendered for each saved API key in the **Saved Keys** list on the Settings page.

Inside the `.map((key) => ...)` block in `src/pages/Settings.tsx`, two `<button>` elements were calling `handleDeleteKey(key.id)` for the same key:

1. A standalone button with proper `disabled` state and a "Deleting…" loading indicator.
2. A second, duplicate button inside the action group `<div>` — lacking the `disabled`/loading logic.

This caused two delete buttons to appear side-by-side per API key, cluttering the UI. The duplicate (the inferior one) has been removed, leaving only the fully-functional button with correct UX states.

Fixes #210

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or console errors

## Verification Details

1. **Steps:**
   - Navigate to the Settings page.
   - Add one or more API keys.
   - Observe the Saved Keys list.
2. **Expected result:** Each API key row displays exactly **one** delete (trash) button. Clicking it deletes the correct key, shows "Deleting…" while in progress, and disables the button to prevent double-clicks.

## Visual Documentation

| Before | After |
|--------|-------|
| Two 🗑️ delete buttons per API key row | One 🗑️ delete button per API key row |