### PR TITLE
Feat: add scroll-to-top button on landing page

### DIFF
--- a/src/components/ScrollToTop.tsx
+++ b/src/components/ScrollToTop.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { ChevronUp } from "lucide-react";
+
+export default function ScrollToTop() {
+  const [isVisible, setIsVisible] = useState(false);
+
+  useEffect(() => {
+    const toggleVisibility = () => {
+      if (window.scrollY > 400) {
+        setIsVisible(true);
+      } else {
+        setIsVisible(false);
+      }
+    };
+
+    window.addEventListener("scroll", toggleVisibility);
+
+    return () => {
+      window.removeEventListener("scroll", toggleVisibility);
+    };
+  }, []);
+
+  const scrollToTop = () => {
+    window.scrollTo({
+      top: 0,
+      behavior: "smooth",
+    });
+  };
+
+  return (
+    <button
+      onClick={scrollToTop}
+      aria-label="Scroll to top"
+      className={`
+        fixed bottom-8 right-8 z-50
+        flex items-center justify-center
+        w-14 h-14 rounded-full
+        bg-linear-to-r from-indigo-500 to-purple-600
+        text-white
+        shadow-[0_0_25px_rgba(99,102,241,0.45)]
+        transition-all duration-300 ease-out
+        hover:scale-110
+        hover:shadow-[0_0_40px_rgba(99,102,241,0.7)]
+        active:scale-95
+        ${
+          isVisible
+            ? "opacity-100 translate-y-0"
+            : "opacity-0 translate-y-6 pointer-events-none"
+        }
+      `}
+    >
+      <ChevronUp size={26} />
+    </button>
+  );
+}

--- a/src/pages/LandingPage.tsx
+++ b/src/pages/LandingPage.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback, type ReactNode } from "react";
 import { Link as RouterLink } from "react-router-dom";
 import { motion } from "framer-motion";
 import demoImage from "../components/image.png";
+import ScrollToTop from "../components/ScrollToTop";
 import {
     MessageSquare,
     Zap,
@@ -614,6 +615,7 @@ const LandingPage = () => {
                     </div>
                 </div>
             </footer>
+            <ScrollToTop />
         </div>
     );
 };


### PR DESCRIPTION
## Description

Added a floating **Scroll-to-Top** button to improve navigation across the DocChat landing page.

### Changes Made

* Created a reusable `ScrollToTop` component.
* Added visibility logic to show the button only after the user scrolls down.
* Implemented smooth scrolling animation back to the top of the page.
* Added responsive positioning for desktop and mobile devices.
* Styled the button to match the existing DocChat dark-themed design system with hover effects and transitions.
* Integrated the component into the landing page.

### Files Modified

* `src/components/ScrollToTop.tsx` (new)
* `src/pages/LandingPage.tsx` (or corresponding landing page component)

Fixes #105 

## Type of Change

* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] Refactoring (structural code cleanups with no behavior changes)
* [ ] Performance improvement (indexing speed, search latency, UI responsiveness)
* [ ] Documentation update (non-executable reference upgrades)

## Checklist

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings or console errors
* [ ] I have run tests locally (`pnpm run test` or `vitest run` under `backend/`) and they pass
* [x] Any dependent changes have been merged and published in downstream modules

## Verification Details

1. Open the landing page.
2. Scroll down beyond the hero and content sections.
3. Observe that the Scroll-to-Top button appears at the bottom-right corner.
4. Click the button.
5. Verify that the page smoothly scrolls back to the top.

### Expected Result

* The button remains hidden near the top of the page.
* The button appears after scrolling down.
* Clicking the button smoothly scrolls the user to the top.
* The button is responsive and visually consistent with the DocChat UI.

## Visual Documentation

### Before

Users had to manually scroll back to the top of the page.

### After

A floating Scroll-to-Top button appears after scrolling and provides quick navigation back to the top.

(Screenshot attached)

<img width="1919" height="961" alt="Screenshot 2026-06-13 233033" src="https://github.com/user-attachments/assets/90d019d8-d494-43b7-8b3d-f2f529f60e78" />

<img width="1919" height="954" alt="image" src="https://github.com/user-attachments/assets/98ea0db6-7352-46b4-a5ea-00e7a1c65014" />

