### PR TITLE
fix: persist FAILED status to DB in worker failure handler (#39)

### DIFF
--- a/backend/chatWorker.js
+++ b/backend/chatWorker.js
@@ -402,9 +402,8 @@ worker.on("completed", async (job) => {
 });
 
 worker.on("failed", async (job, err) => {
-    console.log(err);
     console.error(`Job ${job?.id} failed: ${err.message}`);
     if (job?.data?.chatId) {
-        await updateChatProgress(job.data.chatId, { status: "FAILED" });
+        await markChatFailed(job.data.chatId, err);
     }
 });


### PR DESCRIPTION
## Description

The BullMQ `failed` event handler was only updating Redis (`updateChatProgress`), not Postgres. If ingestion fails mid-process, `Chat.status` could remain `QUEUED`/`PROCESSING` in the database while Redis expires, leaving the UI stuck after refresh.

**What changed:** Replaced `updateChatProgress` (Redis-only) with `markChatFailed` in the `worker.on("failed")` handler in `backend/chatWorker.js`. The worker's catch block already calls `markChatFailed` before re-throwing, so this is a belt-and-suspenders safety net for edge cases where an error propagates past the catch block. `markChatFailed` persists `FAILED` status, `failedAt`, and `failureReason` to Postgres and sets Redis to `FAILED`.

Fixes #39

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or console errors
- [ ] I have run tests locally (`pnpm run test` or `vitest run` under `backend/`) and they pass
- [ ] Any dependent changes have been merged and published in downstream modules

## Verification Details

1. Trigger a chat ingestion that will fail (e.g., point to an invalid URL)
2. Observe that `Chat.status` becomes `FAILED` in Postgres and Redis
3. Refresh the page — UI shows `FAILED` status