### PR TITLE
fix: return 409 Conflict for duplicate username during registration (#150)

### DIFF
--- a/backend/controllers/user.controller.js
+++ b/backend/controllers/user.controller.js
@@ -133,9 +133,19 @@ const userRegister = asyncHandler(async (req, res) => {
     if (!existingUser) {
         throw new ApiError(400, "Email not verified. Request a verification code first.");
     }
-    
+
     if (!existingUser.isVerified) {
         throw new ApiError(400, "User not verified");
+    }
+
+    // Check if the username is already taken by a different account
+    const takenUsername = await prisma.user.findUnique({
+        where: { username },
+    });
+
+    // If a user with this username exists and it's not the current registering user, reject
+    if (takenUsername && takenUsername.email !== email) {
+        throw new ApiError(409, "Username is already taken");
     }
 
     const hashedPassword = await hashPassword(password);


### PR DESCRIPTION
## Summary

Fixes #150

## Problem

`userRegister` in `backend/controllers/user.controller.js` did not check
whether the chosen username was already taken by another account. If a
duplicate username was submitted, Prisma hit the `@unique` constraint and
threw a raw database P2002 error instead of a clean API response.

## Changes

- Added a `findUnique` lookup for the requested username before writing
  profile data. If the username belongs to a different account, throws
  `ApiError(409, "Username is already taken")` before the DB write.

## Acceptance Criteria

- [x] Registering with an already-used username returns `409 Conflict`
- [x] Response includes the message `"Username is already taken"`
- [x] Registration flow fails without a raw database exception