### PR TITLE
security: add express rate limiting to prevent abuse

### DIFF
--- a/backend/middlewares/rateLimit.middleware.js
+++ b/backend/middlewares/rateLimit.middleware.js
@@ -1,0 +1,23 @@
+import rateLimit from "express-rate-limit";
+
+export const llmRateLimiter = rateLimit({
+    windowMs: 60 * 1000, // 1 minute
+    max: 10, // Limit each IP to 10 requests per `window` (here, per minute)
+    message: {
+        success: false,
+        message: "Too many messages sent from this IP, please try again after a minute.",
+    },
+    standardHeaders: true, // Return rate limit info in the `RateLimit-*` headers
+    legacyHeaders: false, // Disable the `X-RateLimit-*` headers
+});
+
+export const apiRateLimiter = rateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 100, // Limit each IP to 100 requests per `window` (here, per 15 minutes)
+    message: {
+        success: false,
+        message: "Too many requests from this IP, please try again after 15 minutes.",
+    },
+    standardHeaders: true,
+    legacyHeaders: false,
+});

--- a/backend/routers/chat.route.js
+++ b/backend/routers/chat.route.js
@@ -30,10 +30,12 @@ import {
     streamChatStatus,
 } from "../controllers/chat.controller.js";
 
+import { apiRateLimiter } from "../middlewares/rateLimit.middleware.js";
+
 const chatRouter = Router();
 
 chatRouter.route("/expectation").get(verifyStrictJWT, validate(expectationQuerySchema), expectation);
-chatRouter.route("/create").post(verifyStrictJWT, validate(createChatSchema), createChat);
+chatRouter.route("/create").post(verifyStrictJWT, apiRateLimiter, validate(createChatSchema), createChat);
 chatRouter
     .route("/:chatId/sources")
     .post(verifyStrictJWT, validate(chatIdParamSchema), validate(addChatSourceSchema), verifyChatOwnership, addChatSource)

--- a/backend/routers/chatMessage.route.js
+++ b/backend/routers/chatMessage.route.js
@@ -18,12 +18,14 @@ import {
     getSharedChatMessageSources,
 } from "../controllers/chatMessage.controller.js";
 
+import { llmRateLimiter } from "../middlewares/rateLimit.middleware.js";
+
 const chatMessageRouter = Router();
 
 chatMessageRouter.route("/models").get(verifyStrictJWT, getAvailableModels);
 chatMessageRouter
     .route("/send")
-    .post(verifyStrictJWT, validate(sendMessageSchema), verifyChatOwnership, sendMessage);
+    .post(verifyStrictJWT, llmRateLimiter, validate(sendMessageSchema), verifyChatOwnership, sendMessage);
 chatMessageRouter
     .route("/all/:chatId")
     .get(verifyStrictJWT, validate(chatIdParamSchema, chatMessagesQuerySchema), verifyChatOwnership, getChatMessages);


### PR DESCRIPTION
Fixes #250 
### Description
While the application maps a `DAILY_TOKEN_BUDGET` via Redis, it previously lacked a rapid-fire HTTP rate limiter. A malicious script could burst the `/message/send` endpoint hundreds of times concurrently before the Redis memory updated, successfully bypassing the daily limit.

### Changes
- Installed `express-rate-limit`.
- Created a centralized `backend/middlewares/rateLimit.middleware.js` providing multiple limiter configurations.
- Bound a strict 10 request/min limit to the LLM `/send` route.
- Bound a 100 request/15min limit to the expensive `/create` chat route.

### Type of change
- [x] Security vulnerability patch
- [ ] New feature (non-breaking change which adds functionality)

Labels: Medium, Backend