### PR TITLE
fix: format SSE stream errors correctly to prevent client crashes

### DIFF
--- a/backend/controllers/chatMessage.controller.js
+++ b/backend/controllers/chatMessage.controller.js
@@ -249,7 +249,7 @@ if (!chat.chatSources[0].isVectorLess) {
             }
         }
     } catch (error) {
-        res.end("Stream ended with error.", error.message);
+        res.write(`\n\ndata: {"error": "Stream ended with error: ${error.message.replace(/\n/g, ' ')}"}\n\n`);
     } finally {
         res.end();
     }


### PR DESCRIPTION
Fixes #252
### Description
When an error occurred mid-generation with OpenAI (like a token drop or network failure), the catch block previously executed `res.end("Stream ended with error.", error.message);`. This violated the strict Server-Sent Events (SSE) protocol and caused the React frontend to crash during JSON parsing or fail silently.

### Changes
- Updated `backend/controllers/chatMessage.controller.js` to gracefully stream standard SSE error chunks formatted as `data: {"error": "..."}\n\n`.
- Removed invalid encoding arguments passed to `res.end()`.

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

Labels: Medium, Backend