### PR TITLE
feat: admin user impersonation

### DIFF
--- a/backend/controllers/admin.controller.js
+++ b/backend/controllers/admin.controller.js
@@ -2,6 +2,8 @@ import prisma from "../utils/prismaClient.js";
 import asyncHandler from "../utils/asyncHandler.js";
 import { ApiResponse } from "../utils/ApiResponse.js";
 import { ApiError } from "../utils/ApiError.js";
+import jwt from "jsonwebtoken";
+import { createAuditEvent } from "../utils/audit.js";
 
 const clampPagination = (req) => {
     const page = Math.max(Number(req.query.page || 1), 1);
@@ -339,4 +341,76 @@ const ingestion = asyncHandler(async (req, res) => {
     );
 });
 
-export { overview, users, userDetails, usage, ingestion };
+const impersonate = asyncHandler(async (req, res) => {
+    const { userId } = req.params;
+    const adminUser = req.user;
+
+    const targetUser = await prisma.user.findUnique({
+        where: { id: userId },
+        select: {
+            id: true,
+            fullname: true,
+            username: true,
+            email: true,
+            isVerified: true,
+        },
+    });
+
+    if (!targetUser) {
+        throw new ApiError(404, "User not found");
+    }
+
+    const impersonationToken = jwt.sign(
+        {
+            id: targetUser.id,
+            username: targetUser.username,
+            fullname: targetUser.fullname,
+            adminOriginal: adminUser.id,
+        },
+        process.env.ACCESS_TOKEN_SECRET,
+        { expiresIn: "15m" },
+    );
+
+    try {
+        await createAuditEvent("admin.impersonate.start", adminUser.id, null, {
+            targetUserId: targetUser.id,
+            targetUsername: targetUser.username,
+        });
+    } catch (error) {
+        console.error("Failed to write impersonation audit event:", error.message);
+    }
+
+    return res.status(200).json(
+        new ApiResponse(
+            200,
+            {
+                accessToken: impersonationToken,
+                user: {
+                    id: targetUser.id,
+                    fullname: targetUser.fullname,
+                    username: targetUser.username,
+                    email: targetUser.email,
+                },
+            },
+            "Impersonation token generated successfully",
+        ),
+    );
+});
+
+const stopImpersonation = asyncHandler(async (req, res) => {
+    const adminUser = req.user;
+
+    try {
+        await createAuditEvent("admin.impersonate.stop", adminUser.id, null, {
+            adminOriginal: adminUser.id,
+        });
+    } catch (error) {
+        console.error("Failed to write stop impersonation audit event:", error.message);
+    }
+
+    return res.status(200).json(
+        new ApiResponse(200, {}, "Impersonation stopped successfully"),
+    );
+});
+
+export { overview, users, userDetails, usage, ingestion, impersonate, stopImpersonation };

--- a/backend/middlewares/auth.middleware.js
+++ b/backend/middlewares/auth.middleware.js
@@ -18,6 +18,7 @@ const verifyStrictJWT = async (req, res, next) => {
                 fullname: true,
                 username: true,
                 email: true,
+                isAdmin: true,
                 apikeys: true,
                 refreshToken: true,
             },

--- a/backend/routers/admin.route.js
+++ b/backend/routers/admin.route.js
@@ -12,6 +12,8 @@ import {
     userDetails,
     usage,
     ingestion,
+    impersonate,
+    stopImpersonation,
 } from "../controllers/admin.controller.js";
 
 const adminRouter = Router();
@@ -23,5 +25,7 @@ adminRouter.route("/users").get(validate(paginationSchema), users);
 adminRouter.route("/users/:userId").get(validate(userIdParamSchema), userDetails);
 adminRouter.route("/usage").get(validate(rangeSchema), validate(paginationSchema), usage);
 adminRouter.route("/ingestion").get(validate(rangeSchema), validate(paginationSchema), ingestion);
+adminRouter.route("/impersonate/:userId").post(validate(userIdParamSchema), impersonate);
+adminRouter.route("/stop-impersonation").post(stopImpersonation);
 
 export default adminRouter;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,7 @@ import { Usage } from "./pages/Usage";
 import Sandbox from "./pages/Sandbox";
 import { ProtectedRoute, PublicOnlyRoute } from "./components/ProtectedRoute";
 import { isAuthenticated } from "./lib/auth";
+import ImpersonationBanner from "./components/ImpersonationBanner";
 
 // Lazy load route pages
 const Dashboard = lazy(() => import("./pages/Dashboard"));
@@ -48,6 +49,7 @@ function App() {
                     </div>
                 }
             >
+                <ImpersonationBanner />
                 <Routes>
             <Route
                 path="/"

--- a/src/components/ImpersonationBanner.tsx
+++ b/src/components/ImpersonationBanner.tsx
@@ -1,0 +1,46 @@
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { isImpersonating, getImpersonationInfo, stopImpersonation } from "../lib/auth";
+import { adminStopImpersonation } from "../lib/api";
+
+const ImpersonationBanner = () => {
+    const navigate = useNavigate();
+    const [stopping, setStopping] = useState(false);
+
+    if (!isImpersonating()) return null;
+
+    const info = getImpersonationInfo();
+    const targetName = info?.targetUser?.fullname || info?.targetUser?.username || "User";
+
+    const handleStop = async () => {
+        setStopping(true);
+        const restored = stopImpersonation();
+        if (restored) {
+            try {
+                await adminStopImpersonation();
+            } catch {
+                // stop-impersonation is best-effort audit
+            }
+        }
+        navigate("/admin/users");
+    };
+
+    return (
+        <div className="sticky top-0 z-50 w-full bg-amber-600/90 backdrop-blur-sm border-b border-amber-500/30">
+            <div className="max-w-7xl mx-auto px-4 py-2 flex items-center justify-between">
+                <p className="text-amber-50 text-sm font-medium">
+                    You are impersonating <span className="font-bold">{targetName}</span>
+                </p>
+                <button
+                    onClick={handleStop}
+                    disabled={stopping}
+                    className="px-3 py-1 rounded-md bg-amber-800/60 text-amber-50 text-xs font-medium hover:bg-amber-700/60 disabled:opacity-50"
+                >
+                    {stopping ? "Stopping..." : "Stop Impersonation"}
+                </button>
+            </div>
+        </div>
+    );
+};
+
+export default ImpersonationBanner;

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -745,3 +745,17 @@ export const forkSharedChat = (shareToken: string) =>
 
 export const deleteMyData = () =>
     apiRequest<{ message: string }>("/user/delete-my-data?confirm=true", { method: "DELETE" });
+
+export const adminImpersonate = (userId: string) =>
+    apiRequest<{
+        accessToken: string;
+        user: {
+            id: string;
+            fullname?: string | null;
+            username?: string | null;
+            email?: string | null;
+        };
+    }>(`/admin/impersonate/${userId}`, { method: "POST" });
+
+export const adminStopImpersonation = () =>
+    apiRequest<void>("/admin/stop-impersonation", { method: "POST" });

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -3,6 +3,7 @@ import { clearCache } from "./cache";
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || "http://localhost:3000/api/v1";
 
 const AUTH_STORAGE_KEY = "docchat_auth";
+const IMPERSONATION_STORAGE_KEY = "docchat_impersonation";
 
 type AuthUser = {
     id: string;
@@ -16,6 +17,16 @@ type AuthSession = {
     accessToken: string;
     refreshToken?: string;
     user: AuthUser;
+};
+
+type ImpersonationInfo = {
+    originalSession: AuthSession;
+    targetUser: {
+        id: string;
+        fullname?: string | null;
+        username?: string | null;
+        email?: string | null;
+    };
 };
 
 type LoginResponse = {
@@ -106,6 +117,7 @@ export const clearAuthSession = () => {
 
 export const forceSignOut = (redirectTo = "/signin") => {
     clearAuthSession();
+    clearImpersonation();
     clearCache();
 
     if (window.location.pathname !== redirectTo) {
@@ -240,6 +252,73 @@ export const logoutUser = async () => {
     try {
         await request("/user/logout", { method: "GET" });
     } finally {
+        clearImpersonation();
         forceSignOut();
     }
+};
+
+const getStoredImpersonation = (): ImpersonationInfo | null => {
+    try {
+        const raw = localStorage.getItem(IMPERSONATION_STORAGE_KEY);
+        if (!raw) return null;
+        return JSON.parse(raw) as ImpersonationInfo;
+    } catch {
+        return null;
+    }
+};
+
+const setStoredImpersonation = (info: ImpersonationInfo) => {
+    try {
+        localStorage.setItem(IMPERSONATION_STORAGE_KEY, JSON.stringify(info));
+    } catch {
+        // ignore quota errors
+    }
+};
+
+const clearImpersonation = () => {
+    try {
+        localStorage.removeItem(IMPERSONATION_STORAGE_KEY);
+    } catch {
+        // ignore
+    }
+};
+
+export const startImpersonation = (impersonationToken: string, targetUser: ImpersonationInfo["targetUser"]) => {
+    const originalSession = getStoredSession();
+    if (!originalSession) return;
+
+    setStoredImpersonation({
+        originalSession,
+        targetUser,
+    });
+
+    const impersonationSession: AuthSession = {
+        accessToken: impersonationToken,
+        user: {
+            id: targetUser.id,
+            fullname: targetUser.fullname,
+            username: targetUser.username,
+            email: targetUser.email,
+            isAdmin: false,
+        },
+    };
+
+    setAuthSession(impersonationSession);
+};
+
+export const stopImpersonation = (): AuthSession | null => {
+    const info = getStoredImpersonation();
+    if (!info) return null;
+
+    clearImpersonation();
+    setAuthSession(info.originalSession);
+    return info.originalSession;
+};
+
+export const isImpersonating = (): boolean => {
+    return getStoredImpersonation() !== null;
+};
+
+export const getImpersonationInfo = (): ImpersonationInfo | null => {
+    return getStoredImpersonation();
 };

--- a/src/pages/AdminUsers.tsx
+++ b/src/pages/AdminUsers.tsx
@@ -1,14 +1,31 @@
 import { useEffect, useState } from "react";
-import { Link } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 import { Sidebar } from "../components/Sidebar";
-import { getAdminUsers, type AdminUserItem } from "../lib/api";
+import { getAdminUsers, adminImpersonate, type AdminUserItem } from "../lib/api";
+import { startImpersonation } from "../lib/auth";
 
 const AdminUsers = () => {
+    const navigate = useNavigate();
     const [page, setPage] = useState(1);
     const limit = 10;
     const [users, setUsers] = useState<AdminUserItem[]>([]);
     const [totalPages, setTotalPages] = useState(1);
     const [error, setError] = useState("");
+    const [impersonatingId, setImpersonatingId] = useState<string | null>(null);
+
+    const handleImpersonate = async (user: AdminUserItem) => {
+        setImpersonatingId(user.id);
+        setError("");
+        try {
+            const res = await adminImpersonate(user.id);
+            startImpersonation(res.accessToken, res.user);
+            navigate("/dashboard");
+        } catch (err) {
+            setError(err instanceof Error ? err.message : "Failed to start impersonation.");
+        } finally {
+            setImpersonatingId(null);
+        }
+    };
 
     useEffect(() => {
         const load = async () => {
@@ -50,10 +67,17 @@ const AdminUsers = () => {
                                         <td className="py-3 text-white">{user.fullname || user.username || user.id}</td>
                                         <td className="py-3 text-gray-400">{user.email || "—"}</td>
                                         <td className="py-3 text-gray-400">{user.isAdmin ? "Admin" : "User"}</td>
-                                        <td className="py-3 text-right">
+                                        <td className="py-3 text-right space-x-3">
                                             <Link className="text-accent-blue hover:underline" to={`/admin/users/${user.id}`}>
                                                 View user
                                             </Link>
+                                            <button
+                                                onClick={() => handleImpersonate(user)}
+                                                disabled={impersonatingId === user.id}
+                                                className="text-amber-400 hover:text-amber-300 hover:underline disabled:opacity-50 disabled:cursor-not-allowed"
+                                            >
+                                                {impersonatingId === user.id ? "..." : "Impersonate"}
+                                            </button>
                                         </td>
                                     </tr>
                                 ))}


### PR DESCRIPTION
## Summary

Adds admin user impersonation, allowing admins to temporarily view the platform as a target user for debugging and support.

---

## Backend Changes

### `POST /admin/impersonate/:userId`

- Validates the target user exists
- Generates a short-lived (15 min) JWT with:
  - `id`, `username`, `fullname` — target user's identity
  - `adminOriginal` — requesting admin's user ID (audit trail)
- Logs an `admin.impersonate.start` audit event
- Returns `{ accessToken, user }` for the frontend to switch sessions

### `POST /admin/stop-impersonation`

- Logs an `admin.impersonate.stop` audit event
- Returns success (the frontend already restored the original session)

### Fix: `verifyStrictJWT`

Added `isAdmin: true` to the Prisma user select so that the `verifyAdmin` middleware correctly checks admin status (was previously always `undefined`).

---

## Frontend Changes

### `src/lib/auth.ts`

| Export | Description |
|---|---|
| `startImpersonation(token, targetUser)` | Stores original session in `IMPERSONATION_STORAGE_KEY`, replaces main session with impersonation token |
| `stopImpersonation()` | Restores original session from storage, clears impersonation |
| `isImpersonating()` | Checks if impersonation is active |
| `getImpersonationInfo()` | Returns `{ originalSession, targetUser }` |

`forceSignOut` and `logoutUser` now also clear impersonation state to prevent orphaned sessions.

### `src/lib/api.ts`

- `adminImpersonate(userId)` — `POST /admin/impersonate/:userId`
- `adminStopImpersonation()` — `POST /admin/stop-impersonation`

### `src/pages/AdminUsers.tsx`

Each user row now has an "Impersonate" button with loading state:

> ![action column mockup](https://imgur.com/placeholder) <!-- replace with actual screenshot -->
>
> `[View user]  [Impersonate]`

### `src/components/ImpersonationBanner.tsx` (new)

Sticky top banner shown on every page while impersonating:

- Amber background with backdrop blur
- Displays "You are impersonating **{targetName}**"
- "Stop Impersonation" button restores admin session and navigates to `/admin/users`
- `adminStopImpersonation` is called best-effort for audit

### `src/App.tsx`

`<ImpersonationBanner />` rendered inside `<Suspense>` before `<Routes>`.

---

## Security

| Concern | Mitigation |
|---|---|
| Token lifetime | 15 min expiry (`ACCESS_TOKEN_SECRET`) |
| Audit trail | `adminOriginal` JWT claim + `admin.impersonate.start/stop` audit events |
| Admin route guard | `verifyAdmin` checks `req.user.isAdmin` — impersonated non-admin users cannot access admin endpoints |
| Session isolation | Original admin session preserved in localStorage under separate key; full recovery on stop |
| Expired token cleanup | `forceSignOut` clears both main auth and impersonation storage |

---

## Flow

1. Admin clicks "Impersonate" on /admin/users
2. POST /admin/impersonate/:userId → returns JWT for target user
3. Frontend saves original session → switches to impersonation JWT
4. Redirect to /dashboard — admin now sees the app as target user
5. Amber banner visible on every page
6. Admin clicks "Stop Impersonation" on banner
7. Frontend restores original session → POST /admin/stop-impersonation
8. Redirect to /admin/users

Closes #216