### PR TITLE
fix: handle missing MEM0_API_KEY gracefully

### DIFF
--- a/backend/controllers/chatMessage.controller.js
+++ b/backend/controllers/chatMessage.controller.js
@@ -18,7 +18,14 @@ import { buildMessagesForLLM } from "../utils/contextBuilder.js";
 import { MemoryClient } from "mem0ai";
 import { createAuditEvent } from "../utils/audit.js";
 
-const memory = MEM0_ENABLED ? new MemoryClient({ apiKey: process.env.MEM0_API_KEY }) : null;
+let memory = null;
+if (MEM0_ENABLED) {
+    if (process.env.MEM0_API_KEY) {
+        memory = new MemoryClient({ apiKey: process.env.MEM0_API_KEY });
+    } else {
+        console.warn("WARNING: MEM0_ENABLED is true, but MEM0_API_KEY is not set in environment variables. Mem0 integration is disabled.");
+    }
+}
 
 // Daily token budget tracked per user per UTC day.
 const dailyBudgetKey = (userId) => `tokenBudget:${userId}:${new Date().toISOString().slice(0, 10)}`;


### PR DESCRIPTION
Fixes #254 
### Description
The memory integration initializes globally when the controller boots up. If the feature flag `MEM0_ENABLED` was set to `true`, but the `MEM0_API_KEY` was missing from the `.env` file, it would crash the Node process entirely on startup or throw unhandled fatal errors during the first chat. 

### Changes
- Wrapped the memory client instantiation in `backend/controllers/chatMessage.controller.js` with validation checks.
- If the environment variable is missing, it now safely skips initialization and logs a non-fatal terminal warning, allowing the rest of the application to boot smoothly.

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

Labels : Easy, Backend