### PR TITLE
feat: add rate limiting to authentication endpoints

### DIFF
--- a/backend/middlewares/rateLimit.middleware.js
+++ b/backend/middlewares/rateLimit.middleware.js
@@ -1,0 +1,32 @@
+import rateLimit from "express-rate-limit";
+
+const createLimiter = (windowMs, max) =>
+    rateLimit({
+        windowMs,
+        max,
+        standardHeaders: true,
+        legacyHeaders: false,
+        message: {
+            message: "Too many requests, please try again later.",
+        },
+    });
+
+export const loginLimiter = createLimiter(
+    15 * 60 * 1000,
+    10,
+);
+
+export const registerLimiter = createLimiter(
+    15 * 60 * 1000,
+    5,
+);
+
+export const verificationCodeLimiter = createLimiter(
+    10 * 60 * 1000,
+    3,
+);
+
+export const resetPasswordLimiter = createLimiter(
+    15 * 60 * 1000,
+    5,
+);

--- a/backend/package.json
+++ b/backend/package.json
@@ -31,6 +31,7 @@
         "cors": "^2.8.6",
         "dotenv": "^17.3.1",
         "express": "^5.2.1",
+        "express-rate-limit": "^8.5.2",
         "ioredis": "^5.10.1",
         "jsonwebtoken": "^9.0.3",
         "mem0ai": "^2.4.4",

--- a/backend/pnpm-lock.yaml
+++ b/backend/pnpm-lock.yaml
@@ -50,6 +50,9 @@ importers:
       express:
         specifier: ^5.2.1
         version: 5.2.1
+      express-rate-limit:
+        specifier: ^8.5.2
+        version: 8.5.2(express@5.2.1)
       ioredis:
         specifier: ^5.10.1
         version: 5.10.1
@@ -1468,6 +1471,12 @@ packages:
     peerDependencies:
       express: '>= 4.11'
 
+  express-rate-limit@8.5.2:
+    resolution: {integrity: sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      express: '>= 4.11'
+
   express@5.2.1:
     resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
     engines: {node: '>= 18'}
@@ -1733,6 +1742,10 @@ packages:
 
   ip-address@10.1.0:
     resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
+    engines: {node: '>= 12'}
+
+  ip-address@10.2.0:
+    resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
     engines: {node: '>= 12'}
 
   ipaddr.js@1.9.1:
@@ -4650,6 +4663,11 @@ snapshots:
       ip-address: 10.1.0
     optional: true
 
+  express-rate-limit@8.5.2(express@5.2.1):
+    dependencies:
+      express: 5.2.1
+      ip-address: 10.2.0
+
   express@5.2.1:
     dependencies:
       accepts: 2.0.0
@@ -4976,6 +4994,8 @@ snapshots:
 
   ip-address@10.1.0:
     optional: true
+
+  ip-address@10.2.0: {}
 
   ipaddr.js@1.9.1: {}
 

--- a/backend/routers/user.route.js
+++ b/backend/routers/user.route.js
@@ -1,5 +1,11 @@
 import { Router } from "express";
 import { verifyJWT, verifyStrictJWT } from "../middlewares/auth.middleware.js";
+import {
+    loginLimiter,
+    registerLimiter,
+    verificationCodeLimiter,
+    resetPasswordLimiter,
+} from "../middlewares/rateLimit.middleware.js";
 import validate from "../middlewares/validate.middleware.js";
 import {
     sendVerificationCodeSchema,
@@ -24,15 +30,31 @@ import {
 
 const userRouter = Router();
 
-userRouter.route("/send-verification-code").post(validate(sendVerificationCodeSchema), sendVerificationCode);
+userRouter.route("/send-verification-code").post(
+    verificationCodeLimiter,
+    validate(sendVerificationCodeSchema),
+    sendVerificationCode,
+);
 userRouter.route("/verify-email").post(validate(verifyEmailSchema), verifyEmail);
-userRouter.route("/register").post(validate(userRegisterSchema), userRegister);
-userRouter.route("/login").post(validate(userLogInSchema), userLogIn);
+userRouter.route("/register").post(
+    registerLimiter,
+    validate(userRegisterSchema),
+    userRegister,
+);
+userRouter.route("/login").post(
+    loginLimiter,
+    validate(userLogInSchema),
+    userLogIn,
+);
 userRouter.route("/logout").get(verifyStrictJWT, userLogOut);
 userRouter.route("/refresh-tokens").patch(verifyJWT, refreshTokens);
 userRouter.route("/profile").get(verifyStrictJWT, currentUserProfile);
 userRouter.route("/send-reset-code").post(validate(sendResetCodeSchema), sendResetCode);
-userRouter.route("/reset-password").patch(validate(resetPasswordSchema), resetPassword);
+userRouter.route("/reset-password").patch(
+    resetPasswordLimiter,
+    validate(resetPasswordSchema),
+    resetPassword,
+);
 userRouter.route("/delete-my-data").delete(verifyStrictJWT, deleteMyData);
 
 export default userRouter;


### PR DESCRIPTION
## Description

Adds rate limiting protection to authentication-related endpoints to reduce the risk of brute-force attacks and verification code abuse.

Changes made:

- Added `express-rate-limit`
- Created `backend/middlewares/rateLimit.middleware.js`
- Added dedicated limiters for:
  - Login
  - Registration
  - Verification code requests
  - Password reset requests
- Applied rate limiting to authentication routes in `backend/routers/user.route.js`

Fixes #244

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Security improvement

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or console errors
- [x] I have verified the modified files compile successfully

## Verification Details

1. Added and configured `express-rate-limit`.
2. Applied limiters to:
   - `/user/login`
   - `/user/register`
   - `/user/send-verification-code`
   - `/user/reset-password`
3. Verified syntax using:

```bash
node --check middlewares/rateLimit.middleware.js
node --check routers/user.route.js