### PR TITLE
fix: resolve relevantSources type mismatch in chat message controller

### DIFF
--- a/backend/controllers/chatMessage.controller.js
+++ b/backend/controllers/chatMessage.controller.js
@@ -252,9 +252,7 @@ if (!chat.chatSources[0].isVectorLess) {
         score: fusedScores[id],
     }));
 
-    relevantSources = {
-        points: topFusedPoints,
-    };
+    relevantSources = topFusedPoints;
 } else {
         const docTree = await prisma.documentTree.findUnique({
             where: { id: chat.collectionName },


### PR DESCRIPTION
## Description

This PR fixes a bug in vector mode where relevant source citations were always skipped and never saved to the database (resulting in an empty sources panel in the UI). 

`relevantSources` was initialized as an array `[]` but was later reassigned to a plain object `{ points: topFusedPoints }` in `backend/controllers/chatMessage.controller.js`. Because of this type mismatch, subsequent checks (such as `relevantSources.length` and `relevantSources.map(...)`) failed, preventing source citations from being logged to `ChatMessageSource`.

The fix reassigns `relevantSources` directly to the `topFusedPoints` array to restore array-specific functionality.

Fixes #243

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (structural code cleanups with no behavior changes)
- [ ] Performance improvement (indexing speed, search latency, UI responsiveness)
- [ ] Documentation update (non-executable reference upgrades)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or console errors
- [x] I have run tests locally (`pnpm run test` or `vitest run` under `backend/`) and they pass
- [ ] Any dependent changes have been merged and published in downstream modules

## Verification Details

Please describe the tests or manual steps that you ran to verify your changes. Provide instructions so we can reproduce.

1. Test case / steps:
   - Run the unit tests locally from the `backend/` directory:
     ```bash
     node tests/contextBuilder.test.js
     ```
2. Expected result:

<img width="1023" height="280" alt="image" src="https://github.com/user-attachments/assets/2d7954b2-2811-4df6-88be-c22312b5ebdd" />

## Visual Documentation

N/A (Backend logic changes only)