### PR TITLE
feat: Add inline chat renaming functionality to Dashboard and All Chats

### DIFF
--- a/src/pages/AllChats.tsx
+++ b/src/pages/AllChats.tsx
@@ -75,7 +75,7 @@ const AllChats = () => {
     const [renameTarget, setRenameTarget] = useState<ChatRow | null>(null);
     const [renameName, setRenameName] = useState("");
     const [isRenaming, setIsRenaming] = useState(false);
-    const [renameError, setRenameError] = useState("");
+    const isCancellingRef = useRef(false);
 
     const loadChats = async () => {
         setIsLoading(true);
@@ -212,34 +212,32 @@ const AllChats = () => {
         }
     };
 
-    const openRenameModal = (chat: ChatRow) => {
-        setRenameError("");
+    const startRename = (chat: ChatRow) => {
         setRenameTarget(chat);
         setRenameName(chat.title);
     };
 
-    const closeRenameModal = () => {
-        if (isRenaming) return;
-        setRenameError("");
-        setRenameTarget(null);
-        setRenameName("");
+    const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+        if (e.key === "Enter") {
+            e.currentTarget.blur();
+        } else if (e.key === "Escape") {
+            isCancellingRef.current = true;
+            setRenameTarget(null);
+            setRenameName("");
+        }
     };
 
     const handleRename = async () => {
         if (!renameTarget) return;
 
         const nextName = renameName.trim();
-        if (!nextName) {
-            setRenameError("Chat name is required.");
-            return;
-        }
-        if (nextName.length > 100) {
-            setRenameError("Chat name must be 100 characters or fewer.");
+        if (!nextName || nextName === renameTarget.title) {
+            setRenameTarget(null);
+            setRenameName("");
             return;
         }
 
         setIsRenaming(true);
-        setRenameError("");
         setError("");
         try {
             const response = await renameChat(renameTarget.id, nextName);
@@ -250,7 +248,7 @@ const AllChats = () => {
             setRenameTarget(null);
             setRenameName("");
         } catch (err) {
-            setRenameError(err instanceof Error ? err.message : "Failed to rename chat.");
+            setError(err instanceof Error ? err.message : "Failed to rename chat.");
         } finally {
             setIsRenaming(false);
         }
@@ -393,9 +391,41 @@ const AllChats = () => {
                                     <div className="flex items-center gap-4 min-w-0">
                                         {getStatusBadge(chat.status)}
                                         <div className="min-w-0">
-                                            <h3 className="font-medium text-gray-200 truncate">
-                                                {chat.title}
-                                            </h3>
+                                            {renameTarget?.id === chat.id ? (
+                                                <input
+                                                    type="text"
+                                                    value={renameName}
+                                                    onChange={(e) => setRenameName(e.target.value)}
+                                                    onKeyDown={handleKeyDown}
+                                                    onBlur={() => {
+                                                        if (isCancellingRef.current) {
+                                                            isCancellingRef.current = false;
+                                                            return;
+                                                        }
+                                                        handleRename();
+                                                    }}
+                                                    disabled={isRenaming}
+                                                    autoFocus
+                                                    maxLength={100}
+                                                    className="bg-white/5 border border-white/10 rounded px-2 py-0.5 text-sm font-medium text-white focus:outline-none focus:ring-1 focus:ring-accent-blue/50 focus:border-accent-blue/50 w-full max-w-[240px]"
+                                                />
+                                            ) : (
+                                                <div className="flex items-center gap-2 group/title truncate">
+                                                    <h3 className="font-medium text-gray-200 truncate">
+                                                        {chat.title}
+                                                    </h3>
+                                                    <button
+                                                        onClick={(e) => {
+                                                            e.stopPropagation();
+                                                            startRename(chat);
+                                                        }}
+                                                        className="p-1 rounded text-gray-500 hover:text-accent-blue hover:bg-white/5 transition-colors opacity-0 group-hover/title:opacity-100 focus:opacity-100"
+                                                        title="Rename Chat"
+                                                    >
+                                                        <Pencil className="w-3.5 h-3.5" />
+                                                    </button>
+                                                </div>
+                                            )}
                                             <div className="flex flex-wrap gap-1.5 mt-1.5">
                                                 {chat.urls.map((u, i) => (
                                                     <a
@@ -459,13 +489,7 @@ const AllChats = () => {
                                             >
                                                 <Trash2 className="w-4 h-4" />
                                             </button>
-                                            <button
-                                                title="Rename Chat"
-                                                onClick={() => openRenameModal(chat)}
-                                                className="p-1.5 rounded-md text-gray-500 hover:text-accent-blue hover:bg-accent-blue/10 transition-colors"
-                                            >
-                                                <Pencil className="w-4 h-4" />
-                                            </button>
+
                                         </div>
                                     </div>
                                 </div>
@@ -554,77 +578,6 @@ const AllChats = () => {
                     </div>
                 )}
 
-                {/* Rename Chat Modal */}
-                {renameTarget && (
-                    <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
-                        <div
-                            className="absolute inset-0 bg-black/60 backdrop-blur-sm"
-                            onClick={closeRenameModal}
-                        />
-                        <form
-                            onSubmit={(e) => {
-                                e.preventDefault();
-                                handleRename();
-                            }}
-                            className="relative w-full max-w-sm bg-[#0b0b0f] border border-white/10 rounded-2xl shadow-2xl p-6 text-left"
-                        >
-                            <div className="w-14 h-14 rounded-full bg-accent-blue/10 border border-accent-blue/20 flex items-center justify-center mx-auto mb-4">
-                                <Pencil className="w-6 h-6 text-accent-blue" />
-                            </div>
-                            <h3 className="text-lg font-semibold mb-2 text-center">Rename Chat</h3>
-                            <p className="text-sm text-gray-400 mb-4 text-center">
-                                Give <strong className="text-gray-200">"{renameTarget.title}"</strong> a clearer name.
-                            </p>
-                            <label htmlFor="allchats-rename-chat" className="block text-sm text-gray-300 mb-2">
-                                Chat name
-                            </label>
-                            <input
-                                id="allchats-rename-chat"
-                                type="text"
-                                value={renameName}
-                                onChange={(e) => {
-                                    setRenameName(e.target.value);
-                                    if (renameError) setRenameError("");
-                                }}
-                                maxLength={100}
-                                autoFocus
-                                className="w-full rounded-lg border border-white/10 bg-white/5 px-3 py-2.5 text-sm text-white placeholder:text-gray-500 focus:border-accent-blue/50 focus:outline-none focus:ring-1 focus:ring-accent-blue/50"
-                                placeholder="Enter chat name"
-                            />
-                            <p className="mt-2 text-xs text-gray-500">Up to 100 characters.</p>
-                            {renameError && (
-                                <div className="mt-4 flex items-start gap-2 rounded-lg border border-red-500/20 bg-red-500/10 p-3 text-left text-sm text-red-400">
-                                    <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" />
-                                    <span>{renameError}</span>
-                                </div>
-                            )}
-                            <div className="mt-6 flex gap-3">
-                                <button
-                                    type="button"
-                                    onClick={closeRenameModal}
-                                    disabled={isRenaming}
-                                    className="flex-1 px-4 py-2 rounded-lg text-sm font-medium text-gray-400 hover:text-white bg-white/5 hover:bg-white/10 transition-colors disabled:opacity-60"
-                                >
-                                    Cancel
-                                </button>
-                                <button
-                                    type="submit"
-                                    disabled={isRenaming || !renameName.trim() || renameName.trim().length > 100}
-                                    className="flex-1 px-4 py-2 rounded-lg text-sm font-medium text-white bg-accent-blue hover:bg-accent-blue/90 disabled:opacity-60 disabled:cursor-not-allowed transition-colors inline-flex items-center justify-center gap-2"
-                                >
-                                    {isRenaming ? (
-                                        <>
-                                            <Loader2 className="w-4 h-4 animate-spin" />
-                                            Saving...
-                                        </>
-                                    ) : (
-                                        "Save"
-                                    )}
-                                </button>
-                            </div>
-                        </form>
-                    </div>
-                )}
             </main>
         </div>
     );

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -113,7 +113,7 @@ const Dashboard = () => {
     const [renameTarget, setRenameTarget] = useState<Chat | null>(null);
     const [renameName, setRenameName] = useState("");
     const [isRenaming, setIsRenaming] = useState(false);
-    const [renameError, setRenameError] = useState("");
+    const isCancellingRef = useRef(false);
     const [lifetimeTokens, setLifetimeTokens] = useState(0);
     const [failedRuns, setFailedRuns] = useState<FailedIngestionRunItem[]>([]);
     const [searchTerm, setSearchTerm] = useState("");
@@ -468,34 +468,33 @@ const Dashboard = () => {
         }
     };
 
-    const openRenameModal = (chat: Chat) => {
-        setRenameError("");
+    const startRename = (chat: Chat) => {
         setRenameTarget(chat);
         setRenameName(chat.title);
     };
 
-    const closeRenameModal = () => {
-        if (isRenaming) return;
-        setRenameError("");
-        setRenameTarget(null);
-        setRenameName("");
+    const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+        if (e.key === "Enter") {
+            e.currentTarget.blur();
+        } else if (e.key === "Escape") {
+            isCancellingRef.current = true;
+            setRenameTarget(null);
+            setRenameName("");
+        }
     };
 
     const handleRenameChat = async () => {
         if (!renameTarget) return;
 
         const nextName = renameName.trim();
-        if (!nextName) {
-            setRenameError("Chat name is required.");
-            return;
-        }
-        if (nextName.length > 100) {
-            setRenameError("Chat name must be 100 characters or fewer.");
+        if (!nextName || nextName === renameTarget.title) {
+            setRenameTarget(null);
+            setRenameName("");
             return;
         }
 
         setIsRenaming(true);
-        setRenameError("");
+        setError("");
         try {
             const response = await renameChat(renameTarget.id, nextName);
             const updatedName = response?.chat?.name || nextName;
@@ -506,7 +505,7 @@ const Dashboard = () => {
             setRenameName("");
             showToast(`Renamed to "${updatedName}".`);
         } catch (err) {
-            setRenameError(err instanceof Error ? err.message : "Failed to rename chat.");
+            setError(err instanceof Error ? err.message : "Failed to rename chat.");
         } finally {
             setIsRenaming(false);
         }
@@ -817,13 +816,45 @@ const Dashboard = () => {
                                                         className="mt-1"
                                                     />
 
-                                                    <div className="truncate pr-4">
-                                                        <h3
-                                                            className="font-semibold text-gray-100 truncate"
-                                                            title={chat.title}
-                                                        >
-                                                            {chat.title}
-                                                        </h3>
+                                                    <div className="truncate pr-4 flex-1">
+                                                        {renameTarget?.id === chat.id ? (
+                                                            <input
+                                                                type="text"
+                                                                value={renameName}
+                                                                onChange={(e) => setRenameName(e.target.value)}
+                                                                onKeyDown={handleKeyDown}
+                                                                onBlur={() => {
+                                                                    if (isCancellingRef.current) {
+                                                                        isCancellingRef.current = false;
+                                                                        return;
+                                                                    }
+                                                                    handleRenameChat();
+                                                                }}
+                                                                disabled={isRenaming}
+                                                                autoFocus
+                                                                maxLength={100}
+                                                                className="bg-white/5 border border-white/10 rounded px-2 py-0.5 text-sm font-semibold text-white focus:outline-none focus:ring-1 focus:ring-accent-blue/50 focus:border-accent-blue/50 w-full"
+                                                            />
+                                                        ) : (
+                                                            <div className="flex items-center gap-2 group/title truncate">
+                                                                <h3
+                                                                    className="font-semibold text-gray-100 truncate"
+                                                                    title={chat.title}
+                                                                >
+                                                                    {chat.title}
+                                                                </h3>
+                                                                <button
+                                                                    onClick={(e) => {
+                                                                        e.stopPropagation();
+                                                                        startRename(chat);
+                                                                    }}
+                                                                    className="p-1 rounded text-gray-500 hover:text-accent-blue hover:bg-white/5 transition-colors opacity-0 group-hover/title:opacity-100 focus:opacity-100 shrink-0"
+                                                                    title="Rename Chat"
+                                                                >
+                                                                    <Pencil className="w-3.5 h-3.5" />
+                                                                </button>
+                                                            </div>
+                                                        )}
                                                         <div className="flex flex-wrap gap-1.5 mt-2">
                                                             {chat.urls.map((u, i) => (
                                                                 <a
@@ -945,13 +976,7 @@ const Dashboard = () => {
                                                         Retry
                                                     </button>
                                                 )}
-                                                <button
-                                                    aria-label="Rename"
-                                                    onClick={() => openRenameModal(chat)}
-                                                    className="p-2 rounded-lg text-gray-500 hover:text-accent-blue hover:bg-accent-blue/10 transition-colors border border-transparent hover:border-accent-blue/20"
-                                                >
-                                                    <Pencil className="w-4 h-4" />
-                                                </button>
+
                                                 <button
                                                     aria-label="Delete"
                                                     onClick={() => setDeleteTarget(chat)}
@@ -1290,77 +1315,6 @@ const Dashboard = () => {
                 </div>
             )}
 
-            {/* Rename Chat Modal */}
-            {renameTarget && (
-                <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
-                    <div
-                        className="absolute inset-0 bg-black/60 backdrop-blur-sm"
-                        onClick={closeRenameModal}
-                    />
-                    <form
-                        onSubmit={(e) => {
-                            e.preventDefault();
-                            handleRenameChat();
-                        }}
-                        className="relative w-full max-w-sm bg-[#0b0b0f] border border-white/10 rounded-2xl shadow-2xl p-6 text-left"
-                    >
-                        <div className="w-14 h-14 rounded-full bg-accent-blue/10 border border-accent-blue/20 flex items-center justify-center mx-auto mb-4">
-                            <Pencil className="w-6 h-6 text-accent-blue" />
-                        </div>
-                        <h3 className="text-lg font-semibold mb-2 text-center">Rename Chat</h3>
-                        <p className="text-sm text-gray-400 mb-4 text-center">
-                            Give <strong className="text-gray-200">"{renameTarget.title}"</strong> a clearer name.
-                        </p>
-                        <label htmlFor="dashboard-rename-chat" className="block text-sm text-gray-300 mb-2">
-                            Chat name
-                        </label>
-                        <input
-                            id="dashboard-rename-chat"
-                            type="text"
-                            value={renameName}
-                            onChange={(e) => {
-                                setRenameName(e.target.value);
-                                if (renameError) setRenameError("");
-                            }}
-                            maxLength={100}
-                            autoFocus
-                            className="w-full rounded-lg border border-white/10 bg-white/5 px-3 py-2.5 text-sm text-white placeholder:text-gray-500 focus:border-accent-blue/50 focus:outline-none focus:ring-1 focus:ring-accent-blue/50"
-                            placeholder="Enter chat name"
-                        />
-                        <p className="mt-2 text-xs text-gray-500">Up to 100 characters.</p>
-                        {renameError && (
-                            <div className="mt-4 flex items-start gap-2 rounded-lg border border-red-500/20 bg-red-500/10 p-3 text-left text-sm text-red-400">
-                                <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" />
-                                <span>{renameError}</span>
-                            </div>
-                        )}
-                        <div className="mt-6 flex gap-3">
-                            <button
-                                type="button"
-                                onClick={closeRenameModal}
-                                disabled={isRenaming}
-                                className="flex-1 px-4 py-2 rounded-lg text-sm font-medium text-gray-400 hover:text-white bg-white/5 hover:bg-white/10 transition-colors disabled:opacity-60"
-                            >
-                                Cancel
-                            </button>
-                            <button
-                                type="submit"
-                                disabled={isRenaming || !renameName.trim() || renameName.trim().length > 100}
-                                className="flex-1 px-4 py-2 rounded-lg text-sm font-medium text-white bg-accent-blue hover:bg-accent-blue/90 disabled:opacity-60 disabled:cursor-not-allowed transition-colors inline-flex items-center justify-center gap-2"
-                            >
-                                {isRenaming ? (
-                                    <>
-                                        <Loader2 className="w-4 h-4 animate-spin" />
-                                        Saving...
-                                    </>
-                                ) : (
-                                    "Save"
-                                )}
-                            </button>
-                        </div>
-                    </form>
-                </div>
-            )}
 
             {/* Toast Notification */}
             {toast && (


### PR DESCRIPTION
## Description

Replaced the modal-based "Rename Chat" workflow with an inline editing experience for a smoother user interaction. 

Modified `src/pages/Dashboard.tsx` and `src/pages/AllChats.tsx` to:
- Add a pencil edit button directly next to the chat titles in the Dashboard chat cards and the AllChats list rows.
- Replace the title with an inline text input pre-filled with the current name when the edit button is clicked.
- Add keyboard and focus event handlers to the input:
  - `Enter`: Saves changes by blurring the input, which triggers the API call.
  - `Escape`: Reverts changes and exits edit mode immediately.
  - `Blur`: Automatically triggers the PATCH request if the name is valid and changed.
- Remove the old separate rename modal layouts and the separate edit button from the action lists.

Fixes #275

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (structural code cleanups with no behavior changes)
- [ ] Performance improvement (indexing speed, search latency, UI responsiveness)
- [ ] Documentation update (non-executable reference upgrades)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or console errors
- [ ] I have run tests locally (`pnpm run test` or `vitest run` under `backend/`) and they pass
- [ ] Any dependent changes have been merged and published in downstream modules

## Verification Details

Please describe the tests or manual steps that you ran to verify your changes. Provide instructions so we can reproduce.

1. Test case / steps:
   - Go to the Dashboard or All Chats page.
   - Click the pencil icon next to any chat title.
   - Change the text in the input field.
   - Press `Enter` or click outside the input field (triggering `blur`).
   - Also, try editing but pressing `Escape` instead.
2. Expected result:
   - On `Enter`/`blur`: The input turns back into a text label, the chat name updates, and the change is persisted (a toast notification may appear if configured).
   - On `Escape`: The input reverts back to the original title without saving.

## Visual Documentation
