### PR TITLE
fix: prevent oversized fetch payloads during scraping

### DIFF
--- a/backend/tests/ragUtilities.fetchLimit.test.js
+++ b/backend/tests/ragUtilities.fetchLimit.test.js
@@ -1,0 +1,67 @@
+import { describe, it, expect } from "vitest";
+import { safeFetchText } from "../utils/ragUtilities.js";
+
+function createMockResponse({ contentType, contentLength, bodyChunks = [] }) {
+    const chunks = bodyChunks.map((chunk) =>
+        typeof chunk === "string" ? new TextEncoder().encode(chunk) : chunk,
+    );
+    let index = 0;
+
+    return {
+        headers: {
+            get(name) {
+                const key = String(name).toLowerCase();
+                if (key === "content-type") return contentType;
+                if (key === "content-length") return contentLength;
+                return null;
+            },
+        },
+        body: {
+            getReader() {
+                return {
+                    async read() {
+                        if (index >= chunks.length) {
+                            return { done: true, value: undefined };
+                        }
+                        return { done: false, value: chunks[index++] };
+                    },
+                    async cancel() {
+                        index = chunks.length;
+                    },
+                };
+            },
+        },
+    };
+}
+
+describe("safeFetchText", () => {
+    it("rejects payloads larger than the configured limit", async () => {
+        const response = createMockResponse({
+            contentType: "text/html; charset=utf-8",
+            contentLength: String(5 * 1024 * 1024 + 1),
+            bodyChunks: ["<html><body>too big</body></html>"],
+        });
+
+        await expect(safeFetchText(response)).rejects.toThrow("Payload too large");
+    });
+
+    it("rejects unsupported content types", async () => {
+        const response = createMockResponse({
+            contentType: "application/octet-stream",
+            contentLength: "12",
+            bodyChunks: [new Uint8Array([1, 2, 3])],
+        });
+
+        await expect(safeFetchText(response)).rejects.toThrow("Unsupported content type");
+    });
+
+    it("accepts valid html responses", async () => {
+        const response = createMockResponse({
+            contentType: "text/html; charset=utf-8",
+            contentLength: "31",
+            bodyChunks: ["<html><body>Hello</body></html>"],
+        });
+
+        await expect(safeFetchText(response)).resolves.toBe("<html><body>Hello</body></html>");
+    });
+});

--- a/backend/utils/ragUtilities.js
+++ b/backend/utils/ragUtilities.js
@@ -6,6 +6,12 @@ import robotsParser from "robots-parser";
 
 const robotsCache = new Map();
 const domainLimiters = new Map();
+const MAX_FETCH_SIZE_BYTES = 5 * 1024 * 1024; // 5 MB
+const ALLOWED_CONTENT_TYPES = [
+    "text/html",
+    "application/xhtml+xml",
+    "text/plain",
+];
 
 let openai;
 
@@ -184,6 +190,53 @@ async function fetchTextWithTimeout(url, config) {
     }
 }
 
+async function safeFetchText(response) {
+    const contentType = response.headers.get("content-type") || "";
+
+    const allowed = ALLOWED_CONTENT_TYPES.some((type) =>
+        contentType.toLowerCase().includes(type),
+    );
+
+    if (!allowed) {
+        throw new Error(`Unsupported content type: ${contentType}`);
+    }
+
+    const contentLength = Number(response.headers.get("content-length"));
+
+    if (
+        Number.isFinite(contentLength)
+        && contentLength > MAX_FETCH_SIZE_BYTES
+    ) {
+        throw new Error("Payload too large");
+    }
+
+    const reader = response.body?.getReader();
+
+    if (!reader) {
+        throw new Error("Unable to read response body");
+    }
+
+    const chunks = [];
+    let totalBytes = 0;
+
+    while (true) {
+        const { done, value } = await reader.read();
+
+        if (done) break;
+
+        totalBytes += value.length;
+
+        if (totalBytes > MAX_FETCH_SIZE_BYTES) {
+            await reader.cancel();
+            throw new Error("Payload too large");
+        }
+
+        chunks.push(Buffer.from(value));
+    }
+
+    return Buffer.concat(chunks).toString("utf8");
+}
+
 async function fetchRobotsPolicy(origin, config) {
     if (!config.respectRobotsTxt) {
         return {
@@ -211,7 +264,10 @@ async function fetchRobotsPolicy(origin, config) {
             return { parser: parseRobotsTxt("", robotsUrl), crawlDelayMs: null, failureReason: null };
         }
 
-        const parser = parseRobotsTxt(await response.text(), robotsUrl);
+        const parser = parseRobotsTxt(
+            await safeFetchText(response),
+            robotsUrl,
+        );
         return {
             parser,
             crawlDelayMs: getRobotsCrawlDelayMs(parser, config.userAgent),
@@ -298,7 +354,7 @@ async function fetchCrawlText(urlString) {
             throw new Error(`Failed to fetch ${urlString}: HTTP ${response.status}`);
         }
 
-        return response.text();
+        return safeFetchText(response);
     });
 }
 
@@ -556,6 +612,7 @@ export {
     isValidDocUrl,
     scrapeWebpage,
     scrapeTitle,
+    safeFetchText,
     generateVectorEmbeddings,
     getCrawlConfig,
     parseRobotsTxt,


### PR DESCRIPTION
## Description

### Summary

This PR fixes a security vulnerability in the documentation scraping pipeline that could allow excessive memory consumption through unbounded HTTP responses.

### Changes Made

#### Backend (`backend/utils/ragUtilities.js`)

* Added `safeFetchText()` helper to safely process fetched content.
* Added maximum payload size enforcement to prevent oversized responses from being fully loaded into memory.
* Added content-type validation to ensure only supported text-based documentation content is processed.
* Replaced direct `response.text()` usage with guarded fetch handling.
* Applied the protection to both documentation crawling and robots.txt fetching paths.

#### Tests (`backend/tests/ragUtilities.fetchLimit.test.js`)

* Added regression tests covering:

  * Oversized payload rejection.
  * Unsupported content-type rejection.
  * Successful processing of valid text responses.
* Exported the helper where necessary to support isolated testing.

### Rationale

Previously, arbitrary URLs could return extremely large payloads or infinite streams, causing the backend to allocate excessive memory and potentially crash with an Out-Of-Memory (OOM) error.

This implementation introduces payload size limits and content validation to ensure documentation ingestion remains safe and resilient against resource-exhaustion attacks.

Fixes #94

## Type of Change

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] Refactoring (structural code cleanups with no behavior changes)
* [x] Performance improvement (indexing speed, search latency, UI responsiveness)
* [ ] Documentation update (non-executable reference upgrades)

## Checklist

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings or console errors
* [ ] I have run tests locally (`pnpm run test` or `vitest run` under `backend/`) and they pass
* [ ] Any dependent changes have been merged and published in downstream modules

## Verification Details

### Test Case 1: Oversized Payload Protection

**Steps**

1. Create a mock response whose body exceeds the configured maximum payload size.
2. Pass the response through `safeFetchText()`.

**Expected Result**

* The request is aborted.
* An error is thrown indicating the payload size limit was exceeded.
* Memory usage remains bounded.

### Test Case 2: Unsupported Content Type

**Steps**

1. Create a response with a non-text content type (e.g. video/mp4 or application/octet-stream).
2. Pass the response through `safeFetchText()`.

**Expected Result**

* The response is rejected before processing.
* An appropriate validation error is returned.

### Test Case 3: Valid Documentation Response

**Steps**

1. Create a normal HTML/text response within the configured size limit.
2. Process it through `safeFetchText()`.

**Expected Result**

* Content is returned successfully.
* Existing scraping functionality continues to work unchanged.

### Notes

* Added regression tests for payload-size and content-type validation.
* Full backend test execution could not be completed because the repository's Vitest setup requires the PostgreSQL test harness configured by the project.

## Visual Documentation

N/A – Backend security fix only.
