### PR TITLE
feat(cancellation): implement reliable active job cancellation via Redis Pub/Sub and AbortController

### DIFF
--- a/backend/chatWorker.js
+++ b/backend/chatWorker.js
@@ -1,6 +1,6 @@
 import "dotenv/config";
 import { Worker } from "bullmq";
-import redis from "./utils/redis.js";
+import redis, { redisSub } from "./utils/redis.js";
 import {
     normalizeUrl,
     isValidDocUrl,
@@ -30,27 +30,23 @@ function getErrorCode(err) {
     return "UNKNOWN_ERROR";
 }
 
-async function processVector(docsRootUrl, chatId, collectionName, chatSourceId) {
+// Uses BullMQ's native AbortSignal instead of manual Redis polling.
+// signal.aborted is set to true the moment worker.cancelJob(jobId) is called,
+// which we trigger from the pub/sub subscriber below.
+async function processVector(docsRootUrl, chatId, collectionName, chatSourceId, signal) {
     try {
         const rootUrl = normalizeUrl(docsRootUrl);
         console.log("Scraping root:", rootUrl);
 
-        const { internalLinks } = await scrapeWebpage(rootUrl, rootUrl);
-        let allLinks = internalLinks.slice(0, 300); // slice 5 - Just for development, slice 300 for production
+        const { internalLinks } = await scrapeWebpage(rootUrl, rootUrl, { signal });
+        let allLinks = internalLinks.slice(0, 300);
         const totalLinks = allLinks.length;
 
         console.log("Total unique links found:", totalLinks);
 
-        await redis.setex(
-            chatId,
-            3600,
-            JSON.stringify({
-                status: "PROCESSING",
-                current: 0,
-                total: totalLinks,
-                progress: 0,
-            }),
-        );
+        await redis.setex(chatId, 3600, JSON.stringify({
+            status: "PROCESSING", current: 0, total: totalLinks, progress: 0,
+        }));
 
         const collections = await qdrant.getCollections();
         if (!collections.collections.some((c) => c.name === collectionName)) {
@@ -64,36 +60,26 @@ async function processVector(docsRootUrl, chatId, collectionName, chatSourceId) 
         let pageCount = 0;
 
         for (const [index, link] of allLinks.entries()) {
+            // Check BullMQ's native signal between every link
+            if (signal?.aborted) throw Object.assign(new Error("INGESTION_CANCELLED"), { code: "INGESTION_CANCELLED" });
             if (!isValidDocUrl(link, rootUrl)) continue;
 
             try {
-                const { body, title } = await scrapeWebpage(link, rootUrl);
-                const splitter = new RecursiveCharacterTextSplitter({
-                    chunkSize: 1000,
-                    chunkOverlap: 150,
-                });
+                const { body, title } = await scrapeWebpage(link, rootUrl, { signal });
+                const splitter = new RecursiveCharacterTextSplitter({ chunkSize: 1000, chunkOverlap: 150 });
                 const chunks = await splitter.splitText(body);
 
-                batchPage.push({
-                    pageUrl: link,
-                    heading: title,
-                });
-
+                batchPage.push({ pageUrl: link, heading: title });
                 console.log(`Processing: ${link} (${chunks.length} chunks)`);
 
                 for (const chunk of chunks) {
-                    const emb = await generateVectorEmbeddings(chunk);
-
+                    // Check between every embedding call too
+                    if (signal?.aborted) throw Object.assign(new Error("INGESTION_CANCELLED"), { code: "INGESTION_CANCELLED" });
+                    const emb = await generateVectorEmbeddings(chunk, signal);
                     batchPoints.push({
                         id: uuidv4(),
                         vector: emb,
-                        payload: {
-                            url: link,
-                            body: chunk,
-                            chatId,
-                            title,
-                            chatSourceId,
-                        },
+                        payload: { url: link, body: chunk, chatId, title, chatSourceId },
                     });
                 }
 
@@ -102,77 +88,73 @@ async function processVector(docsRootUrl, chatId, collectionName, chatSourceId) 
                 if (pageCount >= 3 || index === totalLinks - 1) {
                     if (batchPoints.length > 0) {
                         console.log(`Upserting batch of ${batchPoints.length} points...`);
-                        await qdrant.upsert(collectionName, {
-                            wait: true,
-                            points: batchPoints,
-                        });
+                        await qdrant.upsert(collectionName, { wait: true, points: batchPoints });
 
-                        await prisma.documentPage
-                            .createMany({
-                                data: batchPage.map((point) => ({
-                                    pageUrl: point.pageUrl,
-                                    heading: point.heading,
-                                    chatSourceId,
-                                })),
-                            })
-                            .catch((err) => {
-                                console.error("Failed to update indexed pages:", err.message);
-                            });
+                        await prisma.documentPage.createMany({
+                            data: batchPage.map((point) => ({
+                                pageUrl: point.pageUrl,
+                                heading: point.heading,
+                                chatSourceId,
+                            })),
+                        }).catch((err) => {
+                            console.error("Failed to update indexed pages:", err.message);
+                        });
 
                         batchPoints = [];
                         batchPage = [];
                         pageCount = 0;
                     }
 
-                    await redis.setex(
-                        chatId,
-                        3600,
-                        JSON.stringify({
-                            status: "PROCESSING",
-                            current: index + 1,
-                            total: totalLinks,
-                            progress: Math.round(((index + 1) / totalLinks) * 100),
-                        }),
-                    );
+                    await redis.setex(chatId, 3600, JSON.stringify({
+                        status: "PROCESSING",
+                        current: index + 1,
+                        total: totalLinks,
+                        progress: Math.round(((index + 1) / totalLinks) * 100),
+                    }));
                 }
             } catch (err) {
+                // Re-throw cancellation so the outer catch handles it properly
+                if (err.code === "INGESTION_CANCELLED" || signal?.aborted) throw err;
                 console.error(`Failed link ${link}:`, err.message);
-                await redis.setex(chatId, 3600, JSON.stringify({ status: "FAILED" }));
                 continue;
             }
         }
     } catch (err) {
-        await redis.setex(chatId, 3600, JSON.stringify({ status: "FAILED" }));
+        if (err.code !== "INGESTION_CANCELLED") {
+            await redis.setex(chatId, 3600, JSON.stringify({ status: "FAILED" }));
+        }
         throw err;
     }
 }
 
-async function processVectorLess(docsRootUrl, chatId, chatSourceId) {
+async function processVectorLess(docsRootUrl, chatId, chatSourceId, signal) {
     try {
         await redis.setex(chatId, 3600, JSON.stringify({ status: "PROCESSING", progress: 0 }));
 
         const rootUrl = normalizeUrl(docsRootUrl);
         console.log("Scraping root:", rootUrl);
 
-        const { internalLinks } = await scrapeWebpage(rootUrl, rootUrl);
-        let allLinks = internalLinks.slice(0, 300); // slice 3 - Just for development, slice 300 for production
+        const { internalLinks } = await scrapeWebpage(rootUrl, rootUrl, { signal });
+        let allLinks = internalLinks.slice(0, 300);
         const totalLinks = allLinks.length;
 
         console.log("Total unique links found:", totalLinks);
 
-        let batchLinks = allLinks.slice(0, 5);
         let allData = "";
         let i = 0;
 
-        while (batchLinks.length > 0) {
-            batchLinks = allLinks.slice(i, i + 5);
+        while (i < totalLinks) {
+            if (signal?.aborted) throw Object.assign(new Error("INGESTION_CANCELLED"), { code: "INGESTION_CANCELLED" });
+
+            const batchLinks = allLinks.slice(i, i + 5);
             const results = await Promise.all(
                 batchLinks.map(async (link) => {
                     if (!isValidDocUrl(link, rootUrl)) return "";
                     try {
-                        const { title, body } = await scrapeWebpage(link, rootUrl);
+                        const { title, body } = await scrapeWebpage(link, rootUrl, { signal });
                         return `Title: ${title}\n ${body}\n\n`;
                     } catch (error) {
+                        if (signal?.aborted) return "";
                         console.error(`Failed: ${link}`, error.message);
                         return "";
                     }
@@ -183,20 +165,17 @@ async function processVectorLess(docsRootUrl, chatId, chatSourceId) {
             i += 5;
         }
 
-        if (!allData.trim()) {
-            throw new Error("No data scraped.");
-        }
+        if (!allData.trim()) throw new Error("No data scraped.");
 
         treeindex.loadData(allData);
         const tree = await treeindex.generateTree();
         console.log("Generated Tree Length:", tree.length);
 
+        // Final check before writing to DB
+        if (signal?.aborted) throw Object.assign(new Error("INGESTION_CANCELLED"), { code: "INGESTION_CANCELLED" });
+
         const docTree = await prisma.documentTree.create({
-            data: {
-                chatSourceId,
-                treeData: tree,
-                sourceData: allData,
-            },
+            data: { chatSourceId, treeData: tree, sourceData: allData },
         });
 
         await redis.setex(chatId, 3600, JSON.stringify({ status: "READY", progress: 100 }));
@@ -217,51 +196,78 @@ async function processVectorLess(docsRootUrl, chatId, chatSourceId) {
 
         return;
     } catch (error) {
-        console.error("Error VectorLess:", error);
-        await redis.setex(chatId, 3600, JSON.stringify({ status: "FAILED" }));
+        if (error.code !== "INGESTION_CANCELLED") {
+            await redis.setex(chatId, 3600, JSON.stringify({ status: "FAILED" }));
+        }
         throw error;
     }
 }
 
 const worker = new Worker(
     "chatCreation",
+    // BullMQ passes the native AbortSignal as the third argument.
+    // Calling worker.cancelJob(jobId) sets signal.aborted = true immediately,
+    // which propagates into scrapeWebpage and generateVectorEmbeddings via fetch({ signal }).
     async (job) => {
-        const { chatId, docsUrl, collectionName, chatSourceId, isVectorLess } = job.data;
+    const { chatId, docsUrl, collectionName, chatSourceId, isVectorLess } = job.data;
+
+    // Own AbortController — BullMQ's native signal isn't a real AbortSignal
+    const controller = new AbortController();
+
+    const cancelChannel = `cancel:${chatId}`;
+    await redisSub.subscribe(cancelChannel);
+
+    const cancelHandler = (channel) => {
+        if (channel === cancelChannel) {
+            console.log(`Cancel signal received for job ${job.id}`);
+            controller.abort();
+        }
+    };
+    redisSub.on("message", cancelHandler);
+
         const run = await prisma.ingestionRun.create({
-            data: {
-                chatId,
-                chatSourceId,
-                status: "STARTED",
-            },
+            data: { chatId, chatSourceId, status: "STARTED" },
         });
 
         try {
             if (!isVectorLess) {
-                await processVector(docsUrl, chatId, collectionName, chatSourceId);
+                await processVector(docsUrl, chatId, collectionName, chatSourceId, controller.signal);
             } else {
-                await processVectorLess(docsUrl, chatId, chatSourceId);
+                await processVectorLess(docsUrl, chatId, chatSourceId, controller.signal);
             }
 
             await prisma.ingestionRun.update({
                 where: { id: run.id },
-                data: {
-                    status: "SUCCESS",
-                    finishedAt: new Date(),
-                    errorCode: null,
-                    errorMessage: null,
-                },
+                data: { status: "SUCCESS", finishedAt: new Date(), errorCode: null, errorMessage: null },
             });
         } catch (err) {
+            const cancelled = err.code === "INGESTION_CANCELLED" || controller.signal.aborted;
+
+            // IngestionRunStatus has no CANCELLED value — always use FAILED
             await prisma.ingestionRun.update({
                 where: { id: run.id },
                 data: {
                     status: "FAILED",
                     finishedAt: new Date(),
                     errorCode: getErrorCode(err),
-                    errorMessage: sanitizeErrorMessage(err?.message),
+                    errorMessage: sanitizeErrorMessage(err.message),
                 },
             });
+
+            if (cancelled) {
+                await prisma.chat.update({
+                    where: { id: chatId },
+                    data: { status: "CANCELLED" },
+                });
+
+                await redis.setex(chatId, 3600, JSON.stringify({ status: "CANCELLED" }));
+            }
+
             throw err;
+        } finally {
+            // Always clean up: unsubscribe and remove the message listener
+            redisSub.off("message", cancelHandler);
+            await redisSub.unsubscribe(cancelChannel);
         }
     },
     {
@@ -274,21 +280,15 @@ const worker = new Worker(
 worker.on("completed", async (job) => {
     console.log(`Job ${job.id} completed!`);
     if (!job.data.isVectorLess) {
-        await redis.setex(
-            job.data.collectionName,
-            3600,
-            JSON.stringify({ status: "READY", progress: 100 }),
-        );
+        await redis.setex(job.data.collectionName, 3600, JSON.stringify({ status: "READY", progress: 100 }));
     }
 
-    await prisma.chat
-        .update({
-            where: { id: job.data.chatId },
-            data: { status: "READY" },
-        })
-        .catch((err) => {
-            console.error("Update status Failed:", err.message);
-        });
+    await prisma.chat.update({
+        where: { id: job.data.chatId },
+        data: { status: "READY" },
+    }).catch((err) => {
+        console.error("Update status Failed:", err.message);
+    });
 });
 
 worker.on("failed", (job, err) => {

--- a/backend/chatWorker.js
+++ b/backend/chatWorker.js
@@ -1,16 +1,33 @@
 import "dotenv/config";
 import { Worker } from "bullmq";
-import redis, { redisSub } from "./utils/redis.js";
+import crypto from "crypto";
+import redis, { getChatProgressKey, updateChatProgress, redisSub } from "./utils/redis.js";
+import { dispatchAlert } from "./utils/notificationDispatcher.js";
+import { getChatCreationQueue } from "./utils/queue.js";
+
+/**
+ * Redis Ingestion Progress Payload Shape:
+ * {
+ *   "status": "QUEUED" | "PROCESSING" | "READY" | "FAILED" | "CANCELLED",
+ *   "progress": number,       // 0 to 100 percentage
+ *   "current": number,        // number of pages processed so far
+ *   "total": number,          // total pages to be processed
+ *   "failureReason": string   // optional message if failed
+ * }
+ */
 import {
     normalizeUrl,
     isValidDocUrl,
     scrapeWebpage,
     generateVectorEmbeddings,
+    splitDocumentationContent,
 } from "./utils/ragUtilities.js";
-import { RecursiveCharacterTextSplitter } from "@langchain/textsplitters";
 import { treeindex, qdrant } from "./utils/ragClients.js";
 import { v4 as uuidv4 } from "uuid";
+import Bottleneck from "bottleneck";
 import prisma from "./utils/prismaClient.js";
+import { recordIngestionJobDuration } from "./utils/metrics.js";
+import { createAuditEvent } from "./utils/audit.js";
 
 function sanitizeErrorMessage(message) {
     if (!message) return null;
@@ -23,6 +40,35 @@ function sanitizeErrorMessage(message) {
     return safe.length > 200 ? `${safe.slice(0, 197)}...` : safe;
 }
 
+async function markChatFailed(chatId, error) {
+    const failureReason = sanitizeErrorMessage(error?.message) || "Ingestion failed";
+
+    await redis.setex(
+        getChatProgressKey(chatId),
+        3600,
+        JSON.stringify({
+            status: "FAILED",
+            progress: 0,
+            failureReason,
+        }),
+    );
+
+    await prisma.chat
+        .update({
+            where: { id: chatId },
+            data: {
+                status: "FAILED",
+                failedAt: new Date(),
+                failureReason,
+            },
+        })
+        .catch((dbError) => {
+            console.error("Failed to persist chat failure state:", dbError.message);
+        });
+
+    return failureReason;
+}
+
 function getErrorCode(err) {
     if (!err) return "UNKNOWN_ERROR";
     if (typeof err.code === "string" && err.code.trim()) return err.code.trim().slice(0, 64);
@@ -30,155 +76,583 @@ function getErrorCode(err) {
     return "UNKNOWN_ERROR";
 }
 
-// Uses BullMQ's native AbortSignal instead of manual Redis polling.
-// signal.aborted is set to true the moment worker.cancelJob(jobId) is called,
-// which we trigger from the pub/sub subscriber below.
-async function processVector(docsRootUrl, chatId, collectionName, chatSourceId, signal) {
+function getConsecutiveFailKey(chatSourceId) {
+    return `consecutive-fail:${chatSourceId}`;
+}
+
+const QUEUE_DEPTH_THRESHOLD = 50;
+let queueAlertCooldown = 0;
+
+async function checkQueueDepth() {
     try {
+        const now = Date.now();
+        if (now < queueAlertCooldown) return;
+        const counts = await getChatCreationQueue().getJobCounts();
+        const waiting = (counts.waiting || 0) + (counts.delayed || 0);
+        if (waiting > QUEUE_DEPTH_THRESHOLD) {
+            queueAlertCooldown = now + 5 * 60 * 1000;
+            await dispatchAlert({
+                type: "queue_depth",
+                title: "BullMQ Queue Depth Alert",
+                message: `Chat creation queue has ${waiting} pending jobs (threshold: ${QUEUE_DEPTH_THRESHOLD}). Consider scaling workers.`,
+                severity: "warning",
+                source: "chatWorker",
+            });
+        }
+    } catch (error) {
+        console.error("Failed to check queue depth:", error.message);
+    }
+}
+
+setInterval(checkQueueDepth, 60_000);
+
+function readPositiveInt(value, fallback) {
+    const parsed = Number.parseInt(value, 10);
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function getWorkerConfig() {
+    return {
+        maxPagesPerJob: readPositiveInt(process.env.CRAWL_MAX_PAGES_PER_JOB, 300),
+        vectorlessBatchSize: readPositiveInt(process.env.CRAWL_VECTORLESS_BATCH_SIZE, 10),
+        workerConcurrency: readPositiveInt(process.env.CHAT_WORKER_CONCURRENCY, 1),
+        scrapeConcurrency: readPositiveInt(process.env.CRAWL_SCRAPE_CONCURRENCY, 10),
+        embeddingBatchSize: readPositiveInt(process.env.EMBEDDING_BATCH_SIZE, 500),
+        qdrantBatchSize: readPositiveInt(process.env.QDRANT_BATCH_SIZE, 500),
+    };
+}
+
+class ChatCancelledError extends Error {
+    constructor(message = "Chat ingestion cancelled") {
+        super(message);
+        this.name = "ChatCancelledError";
+        this.code = "INGESTION_CANCELLED";
+    }
+}
+
+async function ensureChatActive(chatId, signal) {
+    // Check AbortSignal first — this is set by the pub/sub cancel handler
+    if (signal?.aborted) {
+        throw new ChatCancelledError("Cancellation requested by user");
+    }
+
+    const chat = await prisma.chat.findUnique({
+        where: { id: chatId },
+        select: {
+            id: true,
+            status: true,
+            deletedAt: true,
+        },
+    });
+
+    if (!chat) {
+        throw new ChatCancelledError("Chat no longer exists");
+    }
+
+    if (chat.deletedAt) {
+        throw new ChatCancelledError("Chat was deleted");
+    }
+
+    if (!["QUEUED", "PROCESSING"].includes(chat.status)) {
+        throw new ChatCancelledError(`Chat status changed to ${chat.status}`);
+    }
+
+    return chat;
+}
+
+async function cleanupPartialIngestion(chatSourceId) {
+    await prisma.documentPage.deleteMany({
+        where: { chatSourceId },
+    });
+
+    await prisma.documentTree.deleteMany({
+        where: { chatSourceId },
+    });
+}
+
+function computeContentHash(body) {
+    return crypto.createHash("sha256").update(body).digest("hex");
+}
+
+function getCheckpointKey(chatId) {
+    return `checkpoint:${chatId}`;
+}
+
+async function saveCheckpoint(chatId, processedIndex) {
+    await redis.setex(getCheckpointKey(chatId), 86400, String(processedIndex));
+}
+
+async function getCheckpoint(chatId) {
+    const val = await redis.get(getCheckpointKey(chatId));
+    return val ? Number.parseInt(val, 10) : 0;
+}
+
+async function clearCheckpoint(chatId) {
+    await redis.del(getCheckpointKey(chatId));
+}
+
+async function removeOldQdrantPoints(collectionName, pageUrl) {
+    try {
+        const scroll = await qdrant.scroll(collectionName, {
+            filter: {
+                must: [{ key: "url", match: { value: pageUrl } }],
+            },
+            limit: 100,
+        });
+        if (scroll.points.length > 0) {
+            const pointIds = scroll.points.map((p) => p.id);
+            await qdrant.delete(collectionName, {
+                wait: true,
+                points: pointIds,
+            });
+        }
+    } catch (err) {
+        console.error(`Failed to remove old Qdrant points for ${pageUrl}:`, err.message);
+    }
+}
+
+async function getActivePages(chatSourceId) {
+    const pages = await prisma.documentPage.findMany({
+        where: { chatSourceId, isActive: true },
+    });
+    return new Map(pages.map((p) => [p.pageUrl, p]));
+}
+
+async function markPagesRemoved(chatSourceId, currentUrls) {
+    const stale = await prisma.documentPage.findMany({
+        where: {
+            chatSourceId,
+            isActive: true,
+            pageUrl: { notIn: currentUrls },
+        },
+    });
+    if (stale.length === 0) return stale;
+
+    await prisma.documentPage.updateMany({
+        where: { id: { in: stale.map((p) => p.id) } },
+        data: { isActive: false },
+    });
+    return stale;
+}
+
+function isChatSourceReady(chatSource) {
+    if (!chatSource) return false;
+    if (chatSource.isVectorLess) return Boolean(chatSource.documentTree);
+    return (chatSource._count?.pagesIndexed ?? 0) > 0;
+}
+
+async function refreshChatStatus(chatId) {
+    const chat = await prisma.chat.findUnique({
+        where: { id: chatId },
+        include: {
+            chatSources: {
+                include: {
+                    documentTree: true,
+                    _count: {
+                        select: { pagesIndexed: true },
+                    },
+                },
+            },
+        },
+    });
+
+    if (!chat) return;
+    const allReady = chat.chatSources.length > 0 && chat.chatSources.every(isChatSourceReady);
+    await prisma.chat.update({
+        where: { id: chatId },
+        data: { status: allReady ? "READY" : "QUEUED" },
+    });
+
+    await redis.setex(
+        chatId,
+        3600,
+        JSON.stringify({
+            status: allReady ? "READY" : "PROCESSING",
+            progress: allReady ? 100 : 0,
+        }),
+    );
+}
+
+async function processVector(docsRootUrl, chatId, collectionName, chatSourceId, scrapeLimit, signal) {
+    let pagesCrawled = 0;
+    let pagesFailed = 0;
+    try {
+        await ensureChatActive(chatId, signal);
+        const { maxPagesPerJob, scrapeConcurrency, embeddingBatchSize, qdrantBatchSize } = getWorkerConfig();
         const rootUrl = normalizeUrl(docsRootUrl);
         console.log("Scraping root:", rootUrl);
 
         const { internalLinks } = await scrapeWebpage(rootUrl, rootUrl, { signal });
-        let allLinks = internalLinks.slice(0, 300);
+        const effectiveLimit = Math.min(
+            typeof scrapeLimit === "number" && scrapeLimit > 0 ? scrapeLimit : maxPagesPerJob,
+            maxPagesPerJob,
+        );
+        const allLinks = internalLinks.slice(0, effectiveLimit).filter((link) => isValidDocUrl(link, rootUrl));
         const totalLinks = allLinks.length;
 
-        console.log("Total unique links found:", totalLinks);
+        console.log("Total unique valid links found:", totalLinks);
 
-        await redis.setex(chatId, 3600, JSON.stringify({
-            status: "PROCESSING", current: 0, total: totalLinks, progress: 0,
-        }));
+        const resumeFrom = await getCheckpoint(chatId);
+        if (resumeFrom > 0) {
+            console.log(`Resuming from page ${resumeFrom} of ${totalLinks}`);
+        }
+
+        const existingPages = await getActivePages(chatSourceId);
+
+        await updateChatProgress(chatId, {
+            status: "SCRAPING",
+            current: resumeFrom,
+            total: totalLinks,
+            progress: totalLinks > 0 ? Math.round((resumeFrom / totalLinks) * 100) : 0,
+        });
 
         const collections = await qdrant.getCollections();
         if (!collections.collections.some((c) => c.name === collectionName)) {
             await qdrant.createCollection(collectionName, {
                 vectors: { size: 1536, distance: "Cosine" },
             });
+            await qdrant.createPayloadIndex(collectionName, {
+                field_name: "body",
+                field_schema: "text",
+            });
         }
 
-        let batchPoints = [];
-        let batchPage = [];
-        let pageCount = 0;
+        // Phase 1: Scrape + split all pages concurrently
+        const limiter = new Bottleneck({ maxConcurrent: scrapeConcurrency });
+        let scrapedCount = resumeFrom;
 
-        for (const [index, link] of allLinks.entries()) {
-            // Check BullMQ's native signal between every link
-            if (signal?.aborted) throw Object.assign(new Error("INGESTION_CANCELLED"), { code: "INGESTION_CANCELLED" });
-            if (!isValidDocUrl(link, rootUrl)) continue;
+        const scrapedPages = await Promise.all(
+            allLinks.slice(resumeFrom).map((link) =>
+                limiter.schedule(async () => {
+                    try {
+                        await ensureChatActive(chatId, signal);
+                        const { body, title } = await scrapeWebpage(link, rootUrl, { signal });
+                        const contentHash = computeContentHash(body);
 
-            try {
-                const { body, title } = await scrapeWebpage(link, rootUrl, { signal });
-                const splitter = new RecursiveCharacterTextSplitter({ chunkSize: 1000, chunkOverlap: 150 });
-                const chunks = await splitter.splitText(body);
+                        const existing = existingPages.get(link);
+                        if (existing && existing.contentHash === contentHash) {
+                            console.log(`Skipping unchanged: ${link}`);
+                            pagesCrawled++;
+                            scrapedCount++;
+                            await saveCheckpoint(chatId, scrapedCount);
+                            await updateChatProgress(chatId, {
+                                status: "SCRAPING",
+                                current: scrapedCount,
+                                total: totalLinks,
+                                progress: Math.round((scrapedCount / totalLinks) * 50),
+                            });
+                            return null;
+                        }
 
-                batchPage.push({ pageUrl: link, heading: title });
-                console.log(`Processing: ${link} (${chunks.length} chunks)`);
+                        const chunkObjects = splitDocumentationContent(body, {
+                            chunkSize: 1000,
+                            chunkOverlap: 150,
+                        });
+                        const chunks = chunkObjects.map((chunk) => chunk.content);
+                        console.log(`Scraped: ${link} (${chunks.length} chunks)`);
 
-                for (const chunk of chunks) {
-                    // Check between every embedding call too
-                    if (signal?.aborted) throw Object.assign(new Error("INGESTION_CANCELLED"), { code: "INGESTION_CANCELLED" });
-                    const emb = await generateVectorEmbeddings(chunk, signal);
-                    batchPoints.push({
-                        id: uuidv4(),
-                        vector: emb,
-                        payload: { url: link, body: chunk, chatId, title, chatSourceId },
+                        pagesCrawled++;
+                        scrapedCount++;
+                        await saveCheckpoint(chatId, scrapedCount);
+                        await updateChatProgress(chatId, {
+                            status: "SCRAPING",
+                            current: scrapedCount,
+                            total: totalLinks,
+                            progress: Math.round((scrapedCount / totalLinks) * 50),
+                        });
+
+                        return { chunks, chunkObjects, title, link, contentHash, existing };
+                    } catch (err) {
+                        // Re-throw cancellation immediately
+                        if (err instanceof ChatCancelledError || signal?.aborted) throw err;
+                        pagesFailed++;
+                        console.error(`Failed link ${link}:`, err.message);
+                        scrapedCount++;
+                        await saveCheckpoint(chatId, scrapedCount);
+                        await updateChatProgress(chatId, {
+                            status: "SCRAPING",
+                            current: scrapedCount,
+                            total: totalLinks,
+                            progress: Math.round((scrapedCount / totalLinks) * 50),
+                        });
+                        return null;
+                    }
+                }),
+            ),
+        );
+
+        const validPages = scrapedPages.filter(Boolean);
+        if (validPages.length === 0) {
+            throw new Error("No pages were successfully scraped.");
+        }
+
+        // Phase 2: Embed + index in batches
+        let indexedCount = 0;
+        const totalIndexPages = validPages.length;
+
+        await updateChatProgress(chatId, {
+            status: "INDEXING",
+            current: 0,
+            total: totalIndexPages,
+            progress: 50,
+        });
+
+        const pendingPoints = [];
+        const newPageRecords = [];
+
+        async function flushBatch() {
+            if (pendingPoints.length > 0) {
+                const points = pendingPoints.splice(0);
+                await qdrant.upsert(collectionName, { wait: true, points });
+            }
+            if (newPageRecords.length > 0) {
+                const records = newPageRecords.splice(0);
+                await prisma.documentPage.createMany({ data: records }).catch((err) => {
+                    console.error("Failed to create indexed pages:", err.message);
+                });
+            }
+        }
+
+        for (const page of validPages) {
+            await ensureChatActive(chatId, signal);
+            const { chunks, chunkObjects, title, link, contentHash, existing } = page;
+
+            if (chunks.length > 0) {
+                if (existing) {
+                    await removeOldQdrantPoints(collectionName, link);
+                }
+
+                const batchPromises = [];
+                for (let i = 0; i < chunks.length; i += embeddingBatchSize) {
+                    const chunkBatch = chunks.slice(i, i + embeddingBatchSize);
+                    batchPromises.push(generateVectorEmbeddings(chunkBatch, signal));
+                }
+                const batchResults = await Promise.all(batchPromises);
+                const allEmbeddings = batchResults.flatMap((r) => (Array.isArray(r) ? r : [r]));
+
+                const points = chunks.map((chunk, i) => ({
+                    id: uuidv4(),
+                    vector: allEmbeddings[i],
+                    payload: {
+                        url: link,
+                        body: chunk,
+                        chatId,
+                        title,
+                        chatSourceId,
+                        heading: chunkObjects[i]?.heading ?? null,
+                        hasCodeBlock: Boolean(chunkObjects[i]?.hasCodeBlock),
+                        chunkType: chunkObjects[i]?.chunkType ?? "content",
+                    },
+                }));
+
+                pendingPoints.push(...points);
+
+                if (existing) {
+                    await prisma.documentPage
+                        .update({
+                            where: { id: existing.id },
+                            data: { contentHash, lastFetchedAt: new Date(), heading: title },
+                        })
+                        .catch((err) => {
+                            console.error("Failed to update indexed page:", err.message);
+                        });
+                } else {
+                    newPageRecords.push({
+                        pageUrl: link,
+                        heading: title,
+                        chatSourceId,
+                        contentHash,
+                        lastFetchedAt: new Date(),
                     });
                 }
 
-                pageCount++;
-
-                if (pageCount >= 3 || index === totalLinks - 1) {
-                    if (batchPoints.length > 0) {
-                        console.log(`Upserting batch of ${batchPoints.length} points...`);
-                        await qdrant.upsert(collectionName, { wait: true, points: batchPoints });
-
-                        await prisma.documentPage.createMany({
-                            data: batchPage.map((point) => ({
-                                pageUrl: point.pageUrl,
-                                heading: point.heading,
-                                chatSourceId,
-                            })),
-                        }).catch((err) => {
-                            console.error("Failed to update indexed pages:", err.message);
-                        });
-
-                        batchPoints = [];
-                        batchPage = [];
-                        pageCount = 0;
-                    }
-
-                    await redis.setex(chatId, 3600, JSON.stringify({
-                        status: "PROCESSING",
-                        current: index + 1,
-                        total: totalLinks,
-                        progress: Math.round(((index + 1) / totalLinks) * 100),
-                    }));
+                if (pendingPoints.length >= qdrantBatchSize) {
+                    await flushBatch();
                 }
-            } catch (err) {
-                // Re-throw cancellation so the outer catch handles it properly
-                if (err.code === "INGESTION_CANCELLED" || signal?.aborted) throw err;
-                console.error(`Failed link ${link}:`, err.message);
-                continue;
             }
+
+            indexedCount++;
+            await updateChatProgress(chatId, {
+                status: "INDEXING",
+                current: indexedCount,
+                total: totalIndexPages,
+                progress: 50 + Math.round((indexedCount / totalIndexPages) * 50),
+            });
         }
+
+        await flushBatch();
+
+        const removedPages = await markPagesRemoved(chatSourceId, allLinks);
+        for (const page of removedPages) {
+            await removeOldQdrantPoints(collectionName, page.pageUrl);
+            console.log(`Removed deleted page: ${page.pageUrl}`);
+        }
+
+        await clearCheckpoint(chatId);
+
+        await prisma.chatSource.update({
+            where: { id: chatSourceId },
+            data: { collectionName },
+        });
+
+        await prisma.chatSource.update({
+            where: { id: chatSourceId },
+            data: { totalPages: allLinks.length },
+        });
+
+        return { pagesCrawled, pagesFailed };
     } catch (err) {
-        if (err.code !== "INGESTION_CANCELLED") {
-            await redis.setex(chatId, 3600, JSON.stringify({ status: "FAILED" }));
+        err.pagesCrawled = pagesCrawled;
+        err.pagesFailed = pagesFailed;
+        if (err instanceof ChatCancelledError) {
+            await cleanupPartialIngestion(chatSourceId);
+        } else {
+            await markChatFailed(chatId, err);
         }
         throw err;
     }
 }
 
-async function processVectorLess(docsRootUrl, chatId, chatSourceId, signal) {
+async function processVectorLess(docsRootUrl, chatId, chatSourceId, scrapeLimit, signal) {
+    let pagesCrawled = 0;
+    let pagesFailed = 0;
     try {
-        await redis.setex(chatId, 3600, JSON.stringify({ status: "PROCESSING", progress: 0 }));
+        await ensureChatActive(chatId, signal);
+        const { maxPagesPerJob, vectorlessBatchSize } = getWorkerConfig();
+        await updateChatProgress(chatId, { status: "SCRAPING", progress: 0 });
 
         const rootUrl = normalizeUrl(docsRootUrl);
         console.log("Scraping root:", rootUrl);
 
         const { internalLinks } = await scrapeWebpage(rootUrl, rootUrl, { signal });
-        let allLinks = internalLinks.slice(0, 300);
+        const effectiveLimit =
+            typeof scrapeLimit === "number" && scrapeLimit > 0 ? scrapeLimit : maxPagesPerJob;
+        let allLinks = internalLinks.slice(0, effectiveLimit);
         const totalLinks = allLinks.length;
 
         console.log("Total unique links found:", totalLinks);
 
         let allData = "";
-        let i = 0;
+        const pages = [];
 
-        while (i < totalLinks) {
-            if (signal?.aborted) throw Object.assign(new Error("INGESTION_CANCELLED"), { code: "INGESTION_CANCELLED" });
+        for (let i = 0; i < totalLinks; i += vectorlessBatchSize) {
+            await ensureChatActive(chatId, signal);
 
-            const batchLinks = allLinks.slice(i, i + 5);
+            const batchLinks = allLinks.slice(i, i + vectorlessBatchSize);
+            if (batchLinks.length === 0) break;
             const results = await Promise.all(
                 batchLinks.map(async (link) => {
-                    if (!isValidDocUrl(link, rootUrl)) return "";
+                    if (!isValidDocUrl(link, rootUrl)) return null;
                     try {
                         const { title, body } = await scrapeWebpage(link, rootUrl, { signal });
-                        return `Title: ${title}\n ${body}\n\n`;
+                        const contentHash = computeContentHash(body);
+                        pagesCrawled++;
+                        return { link, title, body, contentHash };
                     } catch (error) {
-                        if (signal?.aborted) return "";
+                        if (error instanceof ChatCancelledError || signal?.aborted) throw error;
+                        pagesFailed++;
                         console.error(`Failed: ${link}`, error.message);
-                        return "";
+                        return null;
                     }
                 }),
             );
 
-            allData += results.join("");
-            i += 5;
+            for (const res of results) {
+                if (!res) continue;
+                const pageContent = `Title: ${res.title}\n ${res.body}\n\n`;
+                const start = allData.length;
+                allData += pageContent;
+                const end = allData.length;
+                pages.push({
+                    pageUrl: res.link,
+                    heading: res.title,
+                    startIndex: start,
+                    endIndex: end,
+                    contentHash: res.contentHash,
+                });
+            }
+
+            await updateChatProgress(chatId, {
+                status: "SCRAPING",
+                current: Math.min(i + vectorlessBatchSize, totalLinks),
+                total: totalLinks,
+                progress: totalLinks
+                    ? Math.round((Math.min(i + vectorlessBatchSize, totalLinks) / totalLinks) * 100)
+                    : 0,
+            });
         }
 
-        if (!allData.trim()) throw new Error("No data scraped.");
+        if (!allData.trim()) {
+            throw new Error("No data scraped.");
+        }
 
         treeindex.loadData(allData);
         const tree = await treeindex.generateTree();
         console.log("Generated Tree Length:", tree.length);
 
         // Final check before writing to DB
-        if (signal?.aborted) throw Object.assign(new Error("INGESTION_CANCELLED"), { code: "INGESTION_CANCELLED" });
+        await ensureChatActive(chatId, signal);
+
+        const removedPages = await markPagesRemoved(chatSourceId, allLinks);
+        for (const page of removedPages) {
+            console.log(`Removed deleted page: ${page.pageUrl}`);
+        }
 
         const docTree = await prisma.documentTree.create({
-            data: { chatSourceId, treeData: tree, sourceData: allData },
+            data: {
+                chatSourceId,
+                treeData: tree,
+                sourceData: allData,
+            },
         });
 
-        await redis.setex(chatId, 3600, JSON.stringify({ status: "READY", progress: 100 }));
+        const existingActive = await prisma.documentPage.findMany({
+            where: { chatSourceId, isActive: true },
+        });
+        const existingMap = new Map(existingActive.map((p) => [p.pageUrl, p]));
+
+        for (const page of pages) {
+            const existing = existingMap.get(page.pageUrl);
+            if (existing) {
+                await prisma.documentPage
+                    .update({
+                        where: { id: existing.id },
+                        data: {
+                            heading: page.heading,
+                            startIndex: page.startIndex,
+                            endIndex: page.endIndex,
+                            contentHash: page.contentHash,
+                            lastFetchedAt: new Date(),
+                        },
+                    })
+                    .catch((err) => {
+                        console.error("Failed to update indexed page:", err.message);
+                    });
+            } else {
+                await prisma.documentPage
+                    .create({
+                        data: {
+                            pageUrl: page.pageUrl,
+                            heading: page.heading,
+                            chatSourceId,
+                            startIndex: page.startIndex,
+                            endIndex: page.endIndex,
+                            contentHash: page.contentHash,
+                            lastFetchedAt: new Date(),
+                        },
+                    })
+                    .catch((err) => {
+                        console.error("Failed to create indexed page:", err.message);
+                    });
+            }
+        }
+
+        await updateChatProgress(chatId, { status: "READY", progress: 100 });
+
+        await prisma.chatSource.update({
+            where: { id: chatSourceId },
+            data: { collectionName: docTree.id, totalPages: pages.length },
+        });
 
         await prisma.chat.update({
             where: { id: chatId },
@@ -188,16 +662,25 @@ async function processVectorLess(docsRootUrl, chatId, chatSourceId, signal) {
                 chatSources: {
                     update: {
                         where: { id: chatSourceId },
-                        data: { collectionName: docTree.id },
+                        data: {
+                            collectionName: docTree.id,
+                            totalPages: pages.length,
+                        },
                     },
                 },
             },
         });
 
-        return;
+        return { pagesCrawled, pagesFailed };
     } catch (error) {
-        if (error.code !== "INGESTION_CANCELLED") {
-            await redis.setex(chatId, 3600, JSON.stringify({ status: "FAILED" }));
+        error.pagesCrawled = pagesCrawled;
+        error.pagesFailed = pagesFailed;
+        console.error("Error VectorLess:", error);
+        if (error instanceof ChatCancelledError) {
+            await cleanupPartialIngestion(chatSourceId);
+        } else {
+            await updateChatProgress(chatId, { status: "FAILED" });
+            await markChatFailed(chatId, error);
         }
         throw error;
     }
@@ -205,43 +688,92 @@ async function processVectorLess(docsRootUrl, chatId, chatSourceId, signal) {
 
 const worker = new Worker(
     "chatCreation",
-    // BullMQ passes the native AbortSignal as the third argument.
-    // Calling worker.cancelJob(jobId) sets signal.aborted = true immediately,
-    // which propagates into scrapeWebpage and generateVectorEmbeddings via fetch({ signal }).
     async (job) => {
-    const { chatId, docsUrl, collectionName, chatSourceId, isVectorLess } = job.data;
+        const startTime = process.hrtime();
+        const { chatId, docsUrl, collectionName, chatSourceId, isVectorLess, scrapeLimit } = job.data;
 
-    // Own AbortController — BullMQ's native signal isn't a real AbortSignal
-    const controller = new AbortController();
+        // --- Cancellation setup ---
+        // Create a real AbortController so fetch() and OpenAI SDK can abort at network level.
+        // When the controller publishes to cancel:<chatId>, we call controller.abort()
+        // which propagates the AbortSignal into scrapeWebpage and generateVectorEmbeddings.
+        const controller = new AbortController();
+        const cancelChannel = `cancel:${chatId}`;
+        await redisSub.subscribe(cancelChannel);
 
-    const cancelChannel = `cancel:${chatId}`;
-    await redisSub.subscribe(cancelChannel);
-
-    const cancelHandler = (channel) => {
-        if (channel === cancelChannel) {
-            console.log(`Cancel signal received for job ${job.id}`);
-            controller.abort();
-        }
-    };
-    redisSub.on("message", cancelHandler);
+        const cancelHandler = (channel) => {
+            if (channel === cancelChannel) {
+                console.log(`Cancel signal received for job ${job.id}`);
+                controller.abort();
+            }
+        };
+        redisSub.on("message", cancelHandler);
+        // --- End cancellation setup ---
 
         const run = await prisma.ingestionRun.create({
-            data: { chatId, chatSourceId, status: "STARTED" },
+            data: {
+                chatId,
+                chatSourceId,
+                status: "STARTED",
+            },
+        });
+
+        await createAuditEvent("ingestion.started", null, chatId, {
+            ingestionRunId: run.id,
+            chatSourceId,
+            isVectorLess,
         });
 
         try {
+            let stats = { pagesCrawled: 0, pagesFailed: 0 };
             if (!isVectorLess) {
-                await processVector(docsUrl, chatId, collectionName, chatSourceId, controller.signal);
+                stats = await processVector(docsUrl, chatId, collectionName, chatSourceId, scrapeLimit, controller.signal);
             } else {
-                await processVectorLess(docsUrl, chatId, chatSourceId, controller.signal);
+                stats = await processVectorLess(docsUrl, chatId, chatSourceId, scrapeLimit, controller.signal);
             }
+
+            await prisma.chatSource.update({
+                where: { id: chatSourceId },
+                data: { lastIndexedAt: new Date() },
+            });
 
             await prisma.ingestionRun.update({
                 where: { id: run.id },
-                data: { status: "SUCCESS", finishedAt: new Date(), errorCode: null, errorMessage: null },
+                data: {
+                    status: "SUCCESS",
+                    finishedAt: new Date(),
+                    errorCode: null,
+                    errorMessage: null,
+                    pagesCrawled: stats.pagesCrawled,
+                    pagesFailed: stats.pagesFailed,
+                },
+            });
+
+            await createAuditEvent("ingestion.completed", null, chatId, {
+                ingestionRunId: run.id,
+                status: "SUCCESS",
             });
         } catch (err) {
-            const cancelled = err.code === "INGESTION_CANCELLED" || controller.signal.aborted;
+            const cancelled = err instanceof ChatCancelledError || controller.signal.aborted;
+
+            if (cancelled) {
+                // Update chat and Redis to CANCELLED state
+                await prisma.chat
+                    .update({
+                        where: { id: chatId },
+                        data: { status: "CANCELLED" },
+                    })
+                    .catch((dbErr) => {
+                        console.error("Failed to mark chat as CANCELLED:", dbErr.message);
+                    });
+
+                await redis.setex(
+                    getChatProgressKey(chatId),
+                    3600,
+                    JSON.stringify({ status: "CANCELLED", progress: 0 }),
+                );
+            } else {
+                await markChatFailed(chatId, err);
+            }
 
             // IngestionRunStatus has no CANCELLED value — always use FAILED
             await prisma.ingestionRun.update({
@@ -250,48 +782,100 @@ const worker = new Worker(
                     status: "FAILED",
                     finishedAt: new Date(),
                     errorCode: getErrorCode(err),
-                    errorMessage: sanitizeErrorMessage(err.message),
+                    errorMessage: sanitizeErrorMessage(err?.message),
+                    pagesCrawled: err.pagesCrawled || 0,
+                    pagesFailed: err.pagesFailed || 0,
                 },
             });
 
-            if (cancelled) {
-                await prisma.chat.update({
-                    where: { id: chatId },
-                    data: { status: "CANCELLED" },
-                });
-
-                await redis.setex(chatId, 3600, JSON.stringify({ status: "CANCELLED" }));
-            }
+            await createAuditEvent("ingestion.failed", null, chatId, {
+                ingestionRunId: run.id,
+                errorCode: getErrorCode(err),
+                errorMessage: sanitizeErrorMessage(err?.message),
+            });
 
             throw err;
         } finally {
-            // Always clean up: unsubscribe and remove the message listener
+            // Always clean up pub/sub listener to prevent memory leaks
             redisSub.off("message", cancelHandler);
             await redisSub.unsubscribe(cancelChannel);
+
+            const diff = process.hrtime(startTime);
+            const durationInSeconds = diff[0] + diff[1] / 1e9;
+            await recordIngestionJobDuration(durationInSeconds).catch((err) => {
+                console.error("Failed to record job duration metric:", err.message);
+            });
         }
     },
     {
         connection: redis,
+        concurrency: getWorkerConfig().workerConcurrency,
         removeOnComplete: { count: 50 },
         removeOnFail: { count: 500 },
     },
 );
 
-worker.on("completed", async (job) => {
-    console.log(`Job ${job.id} completed!`);
-    if (!job.data.isVectorLess) {
-        await redis.setex(job.data.collectionName, 3600, JSON.stringify({ status: "READY", progress: 100 }));
-    }
+console.log("CHAT WORKER STARTED");
 
-    await prisma.chat.update({
-        where: { id: job.data.chatId },
-        data: { status: "READY" },
-    }).catch((err) => {
-        console.error("Update status Failed:", err.message);
-    });
+worker.on("ready", () => {
+    console.log("WORKER READY");
+});
+
+worker.on("active", (job) => {
+    console.log("JOB ACTIVE:", job.id);
+});
+
+worker.on("completed", (job) => {
+    console.log("JOB COMPLETED:", job.id);
 });
 
 worker.on("failed", (job, err) => {
-    console.log(err);
+    console.log("JOB FAILED:", job?.id, err?.message);
+});
+
+worker.on("completed", async (job) => {
+    console.log(`Job ${job.id} completed!`);
+
+    if (job.data.chatSourceId) {
+        await redis.del(getConsecutiveFailKey(job.data.chatSourceId));
+    }
+
+    await redis.setex(
+        getChatProgressKey(job.data.chatId),
+        3600,
+        JSON.stringify({ status: "READY", progress: 100 }),
+    );
+
+    await prisma.chat
+        .update({
+            where: { id: job.data.chatId },
+            data: { status: "READY" },
+        })
+        .catch((err) => {
+            console.error("Update status Failed:", err.message);
+        });
+});
+
+worker.on("failed", async (job, err) => {
     console.error(`Job ${job?.id} failed: ${err.message}`);
+
+    if (job?.data?.chatId && !(err instanceof ChatCancelledError)) {
+        await markChatFailed(job.data.chatId, err);
+    }
+
+    if (job?.data?.chatSourceId) {
+        const key = getConsecutiveFailKey(job.data.chatSourceId);
+        const count = await redis.incr(key);
+        await redis.expire(key, 86400);
+        if (count >= 3) {
+            await redis.del(key);
+            await dispatchAlert({
+                type: "ingestion_failure",
+                title: "Ingestion Job Failure Alert",
+                message: `Chat source ${job.data.chatSourceId} has failed ${count} consecutive ingestion attempts. Last error: ${err?.message || "Unknown error"}`,
+                severity: "critical",
+                source: "chatWorker",
+            });
+        }
+    }
 });

--- a/backend/controllers/chat.controller.js
+++ b/backend/controllers/chat.controller.js
@@ -124,7 +124,7 @@ const createChat = asyncHandler(async (req, res) => {
                 ),
             );
     } else {
-        const collectionName = !isVectorLessChat ? `${name.replace(/\s+/g, "-")}-${Date.now()}` : null;
+        const collectionName = !isVectorLessChat ? `${name.replace(/[^a-zA-Z0-9-_]/g, "-")}-${Date.now()}` : null;
         const chat = await prisma.chat.create({
             data: {
                 name,
@@ -189,7 +189,7 @@ const progressStatus = asyncHandler(async (req, res) => {
             errorMessage: true,
         },
     });
-    
+
     const redisData = await redis.get(chat.id.toString());
     const progress = redisData ? JSON.parse(redisData) : { status: "QUEUED", progress: 0 };
 
@@ -418,26 +418,58 @@ const cancelProcessing = asyncHandler(async (req, res) => {
         throw new ApiError(404, "Chat not found");
     }
 
-    const jobs = await chatCreationQueue.getJobs(["active", "waiting", "delayed"], 0, -1, false);
-    const job = jobs.find((j) => j.id === chatId);
+    if (chat.status === "CANCELLED" || chat.status === "READY" || chat.status === "FAILED") {
+        throw new ApiError(400, `Chat is already in ${chat.status} state, cannot cancel`);
+    }
+
+    // Look up the job — jobId is set to chatId in createChat
+    const job = await chatCreationQueue.getJob(chatId);
 
     if (job) {
-        await job.remove();
-        await redis.setex(chat.collectionName, 3600, JSON.stringify({ status: "READY", progress: 100 }));
+        const state = await job.getState();
 
-        await prisma.chat
-            .update({
+        if (state === "waiting" || state === "delayed") {
+            // Queued job: remove it directly, no worker involved
+            await job.remove();
+
+            await redis.setex(chatId, 3600, JSON.stringify({ status: "CANCELLED", progress: 0 }));
+
+            await prisma.chat.update({
                 where: { id: chatId },
-                data: { status: "READY" },
-            })
-            .catch((err) => {
-                throw new ApiError(500, `Failed Update: ${err.message}`, err);
+                data: { status: "CANCELLED" },
             });
 
-        res.status(200).json(new ApiResponse(200, null, "Chat processing cancelled successfully"));
-    } else {
-        throw new ApiError(404, "Job not found or already completed");
+            return res.status(200).json(
+                new ApiResponse(200, { cancelled: true }, "Queued job cancelled successfully"),
+            );
+        }
+
+        if (state === "active") {
+            // Active job: publish to the cancel channel.
+            // The worker's pub/sub subscriber receives this and calls worker.cancelJob(jobId),
+            // which triggers BullMQ's native AbortSignal inside the processor.
+            // The worker then handles all DB + Redis status updates itself — we don't touch
+            // them here to avoid a race condition between controller and worker both writing status.
+            await redis.publish(`cancel:${chatId}`, "cancel");
+
+            return res.status(200).json(
+                new ApiResponse(200, { cancelled: true }, "Cancellation signal sent to active job"),
+            );
+        }
     }
+
+    // Job not found in queue (already completed/failed or never queued)
+    // Still mark as cancelled in case it's stuck in PROCESSING state in DB
+    await redis.setex(chatId, 3600, JSON.stringify({ status: "CANCELLED", progress: 0 }));
+
+    await prisma.chat.update({
+        where: { id: chatId },
+        data: { status: "CANCELLED" },
+    });
+
+    return res.status(200).json(
+        new ApiResponse(200, { cancelled: true }, "Cancellation requested successfully"),
+    );
 });
 
 const deleteChat = asyncHandler(async (req, res) => {
@@ -477,14 +509,12 @@ const toggleShare = asyncHandler(async (req, res) => {
     }
 
     if (chat.shareToken) {
-        // Revoke share
         const updatedChat = await prisma.chat.update({
             where: { id: chatId },
             data: { shareToken: null },
         });
         res.status(200).json(new ApiResponse(200, updatedChat, "Chat share revoked successfully"));
     } else {
-        // Generate share token
         const shareToken = crypto.randomUUID();
         const updatedChat = await prisma.chat.update({
             where: { id: chatId },
@@ -526,8 +556,8 @@ const forkSharedChat = asyncHandler(async (req, res) => {
             messages: {
                 include: {
                     sourceChunks: true,
-                }
-            }
+                },
+            },
         },
     });
 
@@ -535,7 +565,6 @@ const forkSharedChat = asyncHandler(async (req, res) => {
         throw new ApiError(404, "Shared chat not found or link has expired");
     }
 
-    // Create a new chat for the current user
     const newChat = await prisma.chat.create({
         data: {
             name: `${originalChat.name} (Fork)`,
@@ -543,12 +572,11 @@ const forkSharedChat = asyncHandler(async (req, res) => {
             status: "READY",
             userId: req.user.id,
             chatSources: {
-                connect: originalChat.chatSources.map(source => ({ id: source.id }))
-            }
-        }
+                connect: originalChat.chatSources.map((source) => ({ id: source.id })),
+            },
+        },
     });
 
-    // Copy messages so the new user has the history
     for (const msg of originalChat.messages) {
         const newMessage = await prisma.chatMessage.create({
             data: {
@@ -557,7 +585,7 @@ const forkSharedChat = asyncHandler(async (req, res) => {
                 llmResponse: msg.llmResponse,
                 llmModel: msg.llmModel,
                 createdAt: msg.createdAt,
-            }
+            },
         });
 
         if (msg.sourceChunks && msg.sourceChunks.length > 0) {
@@ -568,12 +596,14 @@ const forkSharedChat = asyncHandler(async (req, res) => {
                     pageUrl: chunk.pageUrl,
                     score: chunk.score,
                     chatMessageId: newMessage.id,
-                }))
+                })),
             });
         }
     }
 
-    res.status(200).json(new ApiResponse(200, { chatId: newChat.id }, "Chat successfully forked to your account"));
+    res.status(200).json(
+        new ApiResponse(200, { chatId: newChat.id }, "Chat successfully forked to your account"),
+    );
 });
 
 export {

--- a/backend/controllers/chat.controller.js
+++ b/backend/controllers/chat.controller.js
@@ -407,6 +407,9 @@ const listAllPagesIndexed = asyncHandler(async (req, res) => {
     );
 });
 
+// REPLACEMENT for cancelProcessing in chat.controller.js
+// Replace the existing cancelProcessing function with this one.
+
 const cancelProcessing = asyncHandler(async (req, res) => {
     const { chatId } = req.params;
 
@@ -414,25 +417,29 @@ const cancelProcessing = asyncHandler(async (req, res) => {
         where: { id: chatId },
     });
 
-    if (!chat) {
+    if (!chat || chat.deletedAt) {
         throw new ApiError(404, "Chat not found");
     }
 
-    if (chat.status === "CANCELLED" || chat.status === "READY" || chat.status === "FAILED") {
+    if (["CANCELLED", "READY", "FAILED"].includes(chat.status)) {
         throw new ApiError(400, `Chat is already in ${chat.status} state, cannot cancel`);
     }
 
-    // Look up the job — jobId is set to chatId in createChat
-    const job = await chatCreationQueue.getJob(chatId);
+    // Use getJob(chatId) directly — jobId === chatId as set in createChat
+    const job = await getChatCreationQueue().getJob(chatId);
 
     if (job) {
         const state = await job.getState();
 
         if (state === "waiting" || state === "delayed") {
-            // Queued job: remove it directly, no worker involved
+            // Queued job: remove immediately, controller handles DB update
             await job.remove();
 
-            await redis.setex(chatId, 3600, JSON.stringify({ status: "CANCELLED", progress: 0 }));
+            await redis.setex(
+                getChatProgressKey(chatId),
+                3600,
+                JSON.stringify({ status: "CANCELLED", progress: 0 }),
+            );
 
             await prisma.chat.update({
                 where: { id: chatId },
@@ -445,11 +452,10 @@ const cancelProcessing = asyncHandler(async (req, res) => {
         }
 
         if (state === "active") {
-            // Active job: publish to the cancel channel.
-            // The worker's pub/sub subscriber receives this and calls worker.cancelJob(jobId),
-            // which triggers BullMQ's native AbortSignal inside the processor.
-            // The worker then handles all DB + Redis status updates itself — we don't touch
-            // them here to avoid a race condition between controller and worker both writing status.
+            // Active job: publish to pub/sub channel.
+            // The worker's subscriber receives this, calls controller.abort(),
+            // and handles all DB + Redis status updates itself.
+            // We do NOT update DB here to avoid race conditions.
             await redis.publish(`cancel:${chatId}`, "cancel");
 
             return res.status(200).json(
@@ -458,9 +464,12 @@ const cancelProcessing = asyncHandler(async (req, res) => {
         }
     }
 
-    // Job not found in queue (already completed/failed or never queued)
-    // Still mark as cancelled in case it's stuck in PROCESSING state in DB
-    await redis.setex(chatId, 3600, JSON.stringify({ status: "CANCELLED", progress: 0 }));
+    // Job not found in queue (already done or never queued) — still mark cancelled
+    await redis.setex(
+        getChatProgressKey(chatId),
+        3600,
+        JSON.stringify({ status: "CANCELLED", progress: 0 }),
+    );
 
     await prisma.chat.update({
         where: { id: chatId },

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -12,6 +12,7 @@ enum ChatStatus {
     PROCESSING
     READY
     FAILED
+    CANCELLED
 }
 
 enum IngestionRunStatus {

--- a/backend/utils/redis.js
+++ b/backend/utils/redis.js
@@ -1,11 +1,14 @@
 import Redis from "ioredis";
+import { EventEmitter } from "events";
 
-// Primary connection — used for all regular commands (get, set, setex, publish, BullMQ)
 const redis = new Redis({ maxRetriesPerRequest: null });
 
-// Subscriber connection — ioredis connections in subscribe mode can ONLY receive messages,
-// they can no longer issue regular commands. A dedicated connection avoids that conflict.
-export const redisSub = new Redis({ maxRetriesPerRequest: null });
+// Dedicated subscriber connection for Redis Pub/Sub.
+// ioredis connections in subscribe mode cannot issue regular commands,
+// so this must be a separate connection from the primary redis instance.
+const redisSubscriber = new Redis({ maxRetriesPerRequest: null });
+
+export const progressEmitter = new EventEmitter();
 
 redis.on("connect", () => {
     console.log("Redis connected");
@@ -15,12 +18,29 @@ redis.on("error", (err) => {
     console.error("Redis error:", err);
 });
 
-redisSub.on("connect", () => {
-    console.log("Redis subscriber connected");
+redisSubscriber.on("connect", () => {
+    console.log("Redis Subscriber connected");
 });
 
-redisSub.on("error", (err) => {
-    console.error("Redis subscriber error:", err);
+redisSubscriber.on("error", (err) => {
+    console.error("Redis Subscriber error:", err);
 });
+
+redisSubscriber.on("message", (channel, message) => {
+    progressEmitter.emit(channel, message);
+});
+
+export const getChatProgressKey = (chatId) => `chat-progress:${chatId}`;
+export const getChatProgressChannel = (chatId) => `chat-progress-channel:${chatId}`;
+
+export const updateChatProgress = async (chatId, payload) => {
+    const data = JSON.stringify(payload);
+    await redis.setex(getChatProgressKey(chatId), 3600, data);
+    await redis.publish(getChatProgressChannel(chatId), data);
+};
+
+// Also export as redisSub for the cancellation pub/sub subscriber in chatWorker
+export { redisSubscriber };
+export { redisSubscriber as redisSub };
 
 export default redis;

--- a/backend/utils/redis.js
+++ b/backend/utils/redis.js
@@ -1,6 +1,11 @@
 import Redis from "ioredis";
 
+// Primary connection — used for all regular commands (get, set, setex, publish, BullMQ)
 const redis = new Redis({ maxRetriesPerRequest: null });
+
+// Subscriber connection — ioredis connections in subscribe mode can ONLY receive messages,
+// they can no longer issue regular commands. A dedicated connection avoids that conflict.
+export const redisSub = new Redis({ maxRetriesPerRequest: null });
 
 redis.on("connect", () => {
     console.log("Redis connected");
@@ -8,6 +13,14 @@ redis.on("connect", () => {
 
 redis.on("error", (err) => {
     console.error("Redis error:", err);
+});
+
+redisSub.on("connect", () => {
+    console.log("Redis subscriber connected");
+});
+
+redisSub.on("error", (err) => {
+    console.error("Redis subscriber error:", err);
 });
 
 export default redis;


### PR DESCRIPTION
Closes #62
Summary
Implements reliable cancellation of both queued and active ingestion jobs. Previously, GET /chat/cancel/:chatId could only remove waiting jobs — once a job was active, the worker would continue scraping pages and generating embeddings with no way to stop it. This PR fixes that.
What changed and why
backend/utils/redis.js
Added a dedicated redisSub ioredis connection for Pub/Sub subscriptions. ioredis connections that enter subscribe mode can no longer issue regular commands (get, set, publish, etc.), so a separate connection is required to avoid conflicts with the primary redis connection used by BullMQ and the rest of the app.
backend/chatWorker.js

Replaced manual throwIfCancelled Redis polling with an event-driven approach
Worker subscribes to cancel:<chatId> Redis channel at the start of each job
When a cancel message is received, controller.abort() is called immediately
The native AbortSignal from AbortController propagates into:

scrapeWebpage — aborts active fetch requests at the network level
generateVectorEmbeddings — aborts active OpenAI embedding API calls


Both processVector and processVectorLess check signal.aborted between each link and each embedding call to exit cleanly
A finally block always unsubscribes from the cancel channel and removes the message listener to prevent memory leaks between jobs
On cancellation: Chat status → CANCELLED, IngestionRun status → FAILED with errorCode: AbortError (IngestionRunStatus enum has no CANCELLED value)

backend/controllers/chat.controller.js

Rewrote cancelProcessing to use chatCreationQueue.getJob(chatId) instead of scanning all jobs with getJobs() — cleaner since jobId === chatId
Queued jobs: removed directly via job.remove(), controller updates DB and Redis immediately (safe — no worker running)
Active jobs: publishes to cancel:<chatId> Pub/Sub channel and returns — the worker handles all DB and Redis status updates itself, eliminating a race condition where both controller and worker were previously writing CANCELLED status simultaneously
Added guard to reject cancel requests on already-terminal states (CANCELLED, READY, FAILED) with a 400 response
Fixed collection name sanitization: replaced \s+ with [^a-zA-Z0-9-_] so special characters in doc titles don't produce invalid Qdrant collection names

backend/prisma/schema.prisma
Added CANCELLED to ChatStatus enum. SQL migration file not committed per maintainer instruction — run pnpm prisma db push or pnpm prisma migrate dev --name add_cancelled_status locally to apply.
How cancellation works end-to-end
User clicks Cancel
        ↓
GET /chat/cancel/:chatId
        ↓
Job state = "waiting"?  →  job.remove() + update DB immediately
        ↓
Job state = "active"?   →  redis.publish("cancel:<chatId>", "cancel")
        ↓
Worker receives message  →  controller.abort()
        ↓
AbortSignal fires        →  fetch() and OpenAI SDK abort at network level
        ↓
Error caught             →  Chat: CANCELLED, IngestionRun: FAILED
Tested locally

Created chat → ingestion started → cancelled → verified progress.status: "CANCELLED" via /chat/status/:chatId API ✅
Worker terminal showed Cancel signal received and AbortError confirming network-level abort ✅
Re-cancelling an already cancelled chat returns 400 with correct error ✅
Queued job cancellation removes job and updates status immediately ✅

Note on lint/build
pnpm run lint and pnpm run build report errors in pre-existing files (backend/generated/prisma/ auto-generated types, src/pages/SharedChatPage.tsx missing AuthContext, etc.). None of these are introduced by this PR. The changed files (redis.js, chatWorker.js, chat.controller.js) are plain JavaScript and contain no lint violations.
<img width="1566" height="963" alt="Screenshot 2026-06-17 163105" src="https://github.com/user-attachments/assets/b2c9a379-0f4a-4e90-9431-b66651454aa7" />
<img width="1625" height="852" alt="Screenshot 2026-06-17 164757" src="https://github.com/user-attachments/assets/100c6c1f-b83c-47e8-9e8e-3676e2e3eef5" />
