### PR TITLE
Normalized docs URLs to improve knowledge-base reuse

### DIFF
--- a/backend/controllers/chat.controller.js
+++ b/backend/controllers/chat.controller.js
@@ -11,8 +11,6 @@ import redis, {
     redisSubscriber,
 } from "../utils/redis.js";
 import crypto from "crypto";
-import { ApiResponse } from "../utils/ApiResponse.js";
-import { ApiError } from "../utils/ApiError.js";
 import { createAuditEvent } from "../utils/audit.js";
 import { normalizeUrl } from "../utils/ragUtilities.js";
 import { getChatCreationQueue } from "../utils/queue.js";
@@ -1218,6 +1216,7 @@ const chunkPreview = asyncHandler(async (req, res) => {
             "Chunk preview generated successfully",
         ),
     );
+});
 const downloadRawSource = asyncHandler(async (req, res) => {
     const { chatId, sourceId } = req.params;
 
@@ -1260,6 +1259,7 @@ const downloadRawSource = asyncHandler(async (req, res) => {
                 offset: nextOffset,
             });
 
+            for (const point of response.points) {
                 hasData = true;
                 res.write(`--- ${point.payload.title || 'Page'} (${point.payload.url}) ---\n`);
                 res.write(`${point.payload.body}\n\n`);

--- a/backend/tests/ragUtilities.normalization.test.js
+++ b/backend/tests/ragUtilities.normalization.test.js
@@ -1,0 +1,30 @@
+import { describe, it, expect } from "vitest";
+import { normalizeUrl } from "../utils/ragUtilities.js";
+
+describe("normalizeUrl", () => {
+    it("should remove trailing slash", () => {
+        expect(normalizeUrl("https://example.com/docs/")).toBe("https://example.com/docs");
+        expect(normalizeUrl("https://example.com/")).toBe("https://example.com/");
+    });
+
+    it("should remove hash/fragment", () => {
+        expect(normalizeUrl("https://example.com/docs#section")).toBe("https://example.com/docs");
+        expect(normalizeUrl("https://example.com/docs/#section")).toBe("https://example.com/docs");
+    });
+
+    it("should remove known tracking query parameters", () => {
+        expect(normalizeUrl("https://example.com/docs?utm_source=ad")).toBe("https://example.com/docs");
+        expect(normalizeUrl("https://example.com/docs?fbclid=123&gclid=456")).toBe("https://example.com/docs");
+        expect(normalizeUrl("https://example.com/docs?utm_source=google&page=1&utm_campaign=winter")).toBe("https://example.com/docs?page=1");
+    });
+
+    it("should keep and sort meaningful query parameters", () => {
+        expect(normalizeUrl("https://example.com/docs?v=2&lang=en")).toBe("https://example.com/docs?lang=en&v=2");
+        expect(normalizeUrl("https://example.com/docs?version=1.0&page=intro")).toBe("https://example.com/docs?page=intro&version=1.0");
+    });
+
+    it("should strip index.html from path", () => {
+        expect(normalizeUrl("https://example.com/docs/index.html")).toBe("https://example.com/docs");
+        expect(normalizeUrl("https://example.com/docs/index.html?v=3")).toBe("https://example.com/docs?v=3");
+    });
+});

--- a/backend/tests/setup.js
+++ b/backend/tests/setup.js
@@ -2,13 +2,18 @@ import { beforeEach, afterAll } from 'vitest';
 import prisma from '../utils/prismaClient.js';
 
 beforeEach(async () => {
-    // Truncate all tables before each test to guarantee a clean state
-    const tables = await prisma.$queryRaw`
-        SELECT tablename FROM pg_tables WHERE schemaname='public' AND tablename != '_prisma_migrations';
-    `;
-    
-    for (const { tablename } of tables) {
-        await prisma.$executeRawUnsafe(`TRUNCATE TABLE "${tablename}" CASCADE;`);
+    try {
+        // Truncate all tables before each test to guarantee a clean state
+        const tables = await prisma.$queryRaw`
+            SELECT tablename FROM pg_tables WHERE schemaname='public' AND tablename != '_prisma_migrations';
+        `;
+        
+        for (const { tablename } of tables) {
+            await prisma.$executeRawUnsafe(`TRUNCATE TABLE "${tablename}" CASCADE;`);
+        }
+    } catch (err) {
+        // Silent or warn so that purely unit/algorithmic tests still run offline
+        console.warn("Test setup: Postgres DB is offline, skipping truncation:", err.message);
     }
 });
 

--- a/backend/utils/ragUtilities.js
+++ b/backend/utils/ragUtilities.js
@@ -358,7 +358,27 @@ function normalizeUrl(url) {
     const u = new URL(url);
 
     u.hash = "";
-    u.search = "";
+
+    if (u.search) {
+        const trackingParams = new Set([
+            "utm_source", "utm_medium", "utm_campaign", "utm_term", "utm_content", "utm_cid", "utm_reader",
+            "fbclid", "gclid", "dclid", "msclkid", "mc_eid", "yclid",
+            "__hsfp", "__hssc", "__hstc", "hsctatracking"
+        ]);
+        
+        const params = [...u.searchParams.entries()];
+        const filtered = params
+            .filter(([key]) => !trackingParams.has(key.toLowerCase()))
+            .sort(([a], [b]) => a.localeCompare(b));
+            
+        const newSearchParams = new URLSearchParams();
+        for (const [key, value] of filtered) {
+            newSearchParams.append(key, value);
+        }
+        
+        const searchStr = newSearchParams.toString();
+        u.search = searchStr ? `?${searchStr}` : "";
+    }
 
     if (u.pathname.endsWith("/index.html")) {
         u.pathname = u.pathname.replace("/index.html", "");

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -244,6 +244,46 @@ export const getRecentFailedIngestionRuns = (limit = 5) =>
         { method: "GET" },
     );
 
+export function normalizeUrl(url: string): string {
+    try {
+        const u = new URL(url);
+
+        u.hash = "";
+
+        if (u.search) {
+            const trackingParams = new Set([
+                "utm_source", "utm_medium", "utm_campaign", "utm_term", "utm_content", "utm_cid", "utm_reader",
+                "fbclid", "gclid", "dclid", "msclkid", "mc_eid", "yclid",
+                "__hsfp", "__hssc", "__hstc", "hsctatracking"
+            ]);
+            
+            const params = [...u.searchParams.entries()];
+            const filtered = params
+                .filter(([key]) => !trackingParams.has(key.toLowerCase()))
+                .sort(([a], [b]) => a.localeCompare(b));
+                
+            const newSearchParams = new URLSearchParams();
+            for (const [key, value] of filtered) {
+                newSearchParams.append(key, value);
+            }
+            
+            const searchStr = newSearchParams.toString();
+            u.search = searchStr ? `?${searchStr}` : "";
+        }
+
+        if (u.pathname.endsWith("/index.html")) {
+            u.pathname = u.pathname.replace("/index.html", "");
+        }
+        if (u.pathname !== "/" && u.pathname.endsWith("/")) {
+            u.pathname = u.pathname.slice(0, -1);
+        }
+
+        return u.toString();
+    } catch {
+        return url;
+    }
+}
+
 export const createChat = async (payload: {
     name?: string;
     docsUrl?: string;
@@ -251,25 +291,40 @@ export const createChat = async (payload: {
     isVectorLess?: boolean;
     scrapeLimit?: number;
 }) => {
+    const normalizedPayload = {
+        ...payload,
+        docsUrl: payload.docsUrl ? normalizeUrl(payload.docsUrl) : undefined,
+        docsUrls: payload.docsUrls ? payload.docsUrls.map(url => normalizeUrl(url)) : undefined,
+    };
     const result = await apiRequest<{ chatId?: string; id?: string }>("/chat/create", {
         method: "POST",
-        body: JSON.stringify(payload),
+        body: JSON.stringify(normalizedPayload),
     });
     invalidateChatCaches();
     return result;
 };
 
-export const addChatSource = async (chatId: string, payload: { docsUrl: string; isVectorLess?: boolean }) =>
-    apiRequest<{ chatId: string; chatSourceId: string; attached: boolean; status: string }>(`/chat/${chatId}/sources`, {
+export const addChatSource = async (chatId: string, payload: { docsUrl: string; isVectorLess?: boolean }) => {
+    const normalizedPayload = {
+        ...payload,
+        docsUrl: normalizeUrl(payload.docsUrl),
+    };
+    return apiRequest<{ chatId: string; chatSourceId: string; attached: boolean; status: string }>(`/chat/${chatId}/sources`, {
         method: "POST",
-        body: JSON.stringify(payload),
+        body: JSON.stringify(normalizedPayload),
     });
+};
 
-export const removeChatSource = async (chatId: string, payload: { docsUrl: string; isVectorLess?: boolean }) =>
-    apiRequest<{ chatId: string; chatSourceId: string; detached: boolean }>(`/chat/${chatId}/sources`, {
+export const removeChatSource = async (chatId: string, payload: { docsUrl: string; isVectorLess?: boolean }) => {
+    const normalizedPayload = {
+        ...payload,
+        docsUrl: normalizeUrl(payload.docsUrl),
+    };
+    return apiRequest<{ chatId: string; chatSourceId: string; detached: boolean }>(`/chat/${chatId}/sources`, {
         method: "DELETE",
-        body: JSON.stringify(payload),
+        body: JSON.stringify(normalizedPayload),
     });
+};
 
 export const deleteChat = async (chatId: string) => {
     const result = await apiRequest(`/chat/${chatId}`, { method: "DELETE" });


### PR DESCRIPTION
Summary of Changes
URL Normalization (Backend & Frontend): Upgraded normalizeUrl utility to strip hashes/fragments, strip trailing slashes, drop known tracking parameters, and sort remaining query parameters to prevent duplicate ingestion of identical sites. Integrated it into frontend calls (createChat, addChatSource, removeChatSource).
Syntax Fixes in chat.controller.js: Cleaned up duplicated imports and fixed a syntax issue in downloadRawSource (the missing loop header for qdrant.scroll).
Tests & Offline Verification: Added unit tests in ragUtilities.normalization.test.js to cover the new normalization rules and made Vitest's setup robust when running without an active Postgres connection.



closes #80